### PR TITLE
refactor: 모임 내 특정 날짜의 확정된 약속 조회 로직 리팩토링

### DIFF
--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.jpa.repository;
 
+import com.kuit.conet.domain.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.jpa.domain.plan.Plan;
 import com.kuit.conet.jpa.domain.team.Team;
 import jakarta.persistence.EntityManager;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Date;
 import java.util.List;
 
 @Repository
@@ -18,5 +20,15 @@ public class PlanRepository {
     public Long save(Plan plan) {
         em.persist(plan);
         return plan.getId();
+    }
+
+    public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, Date searchDate) {
+        return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime)" +
+                        "from Plan p join p.team t on t.id=:teamId " +
+                        "where p.fixedDate=:searchDate " +
+                        "order by p.fixedTime")
+                .setParameter("teamId", teamId)
+                .setParameter("searchDate", searchDate)
+                .getResultList();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/PlanService.java
@@ -50,22 +50,9 @@ public class PlanService {
     }
 
     public TeamPlanOnDayResponse getPlanOnDay(TeamFixedPlanOnDayRequest request) {
-        Team team = teamRepository.findById(request.getTeamId());
-        List<Plan> fixedPlansOnTeam = team.getFixedPlans();
-        List<TeamFixedPlanOnDay> plansOnDay = getPlansOnDay(fixedPlansOnTeam, new java.sql.Date(request.getSearchDate().getTime()));
+        List<TeamFixedPlanOnDay> fixedPlansOnDay = planRepository.getFixedPlansOnDay(request.getTeamId(), request.getSearchDate());
 
-        return new TeamPlanOnDayResponse(plansOnDay.size(), plansOnDay);
+        return new TeamPlanOnDayResponse(fixedPlansOnDay.size(), fixedPlansOnDay);
     }
 
-    private static List<TeamFixedPlanOnDay> getPlansOnDay(List<Plan> plansOnTeam, Date searchDate) {
-        return plansOnTeam.stream()
-                .filter(plan -> plan.getFixedDate().equals(searchDate))
-                .map(plan -> new TeamFixedPlanOnDay(
-                        plan.getId(),
-                        plan.getName(),
-                        plan.getFixedTime()
-                ))
-                .sorted(Comparator.comparing(TeamFixedPlanOnDay::getTime)) // 시간 오름차순
-                .toList();
-    }
 }


### PR DESCRIPTION
## 변경 사항
Team 조회를 먼저 하고 해당 팀이 가지는 Plan을 조회하는 기존 방식을 수정
->
PlanRepository에서 join 쿼리를 통하여 Plan을 직접적으로 조회
```java
public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, Date searchDate) {
    return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime)" +
                    "from Plan p join p.team t on t.id=:teamId " +
                    "where p.fixedDate=:searchDate " +
                    "order by p.fixedTime")
            .setParameter("teamId", teamId)
            .setParameter("searchDate", searchDate)
            .getResultList();
}
```

<br>

## API Test
<img width="1552" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96233738/ff6d7f1e-14a4-4a1a-b598-b43a88132ac3">
