### PR TITLE
feat: 홈화면 특정 달의 확정된 약속 조회 api JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/config/MvcConfig.java
+++ b/src/main/java/com/kuit/conet/config/MvcConfig.java
@@ -38,7 +38,7 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/bookmark/delete");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/plan/time");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/plan/user-time");
-        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/month");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/plan/month");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/day");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/waiting");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/detail");

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -5,7 +5,7 @@ import com.kuit.conet.dto.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.response.plan.HomePlanOnDayResponse;
 import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.dto.response.plan.WaitingPlanResponse;
-import com.kuit.conet.service.HomeService;
+import com.kuit.conet.jpa.service.HomeService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,19 +32,19 @@ public class HomeController {
      * 홈 특정 날짜의 확정 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 모임 명 / 약속 명
      * - '나'의 직접적인 참여 여부와 무관
      * */
-    @GetMapping("/day")
+/*    @GetMapping("/day")
     public BaseResponse<HomePlanOnDayResponse> getPlanOnDay(HttpServletRequest httpRequest, @ModelAttribute @Valid HomePlanRequest planRequest) {
         HomePlanOnDayResponse response = homeService.getPlanOnDay(httpRequest, planRequest);
         return new BaseResponse<>(response);
-    }
+    }*/
 
     /**
      * 홈 대기 중인 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 모임 명 / 약속 명
      * - '나'의 직접적인 참여 여부와 무관
      * */
-    @GetMapping("/waiting")
+/*    @GetMapping("/waiting")
     public BaseResponse<WaitingPlanResponse> getWaitingPlan(HttpServletRequest httpRequest) {
         WaitingPlanResponse response = homeService.getWaitingPlan(httpRequest);
         return new BaseResponse<>(response);
-    }
+    }*/
 }

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/home")
+@RequestMapping("/plan")
 public class HomeController {
     private final HomeService homeService;
 

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
@@ -43,8 +43,9 @@ public class Plan {
     @Temporal(TemporalType.TIME)
     private Time fixedTime;
 
-    @ColumnDefault("1")
-    private Integer status;
+    @ColumnDefault("WAITING")
+    @Enumerated(EnumType.STRING)
+    private PlanStatus status;
 
     @OneToMany(mappedBy = "plan")// 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<PlanMember> plans = new ArrayList<>();

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
@@ -1,0 +1,15 @@
+package com.kuit.conet.jpa.domain.plan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public enum PlanStatus {
+    FIXED("FIXED"),   // 확정
+    WAITING("WAITING");   // 대기
+
+    private String planStatus;
+}

--- a/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
@@ -1,0 +1,30 @@
+package com.kuit.conet.jpa.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Date;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Getter
+public class HomeRepository {
+    private final EntityManager em;
+
+    public List<Date> getPlanInMonth(Long userId, String searchDate) {
+        // 해당 년, 월에 유저가 포함된 모든 모임의 모든 약속 -> fixed_date 만 distinct 로 검색
+        // team_member(userId, status) -> plan(teamId, fixed_date, status)
+
+        return em.createQuery("select distinct p.fixedDate " +
+                        "from TeamMember tm join Plan p on tm.team.id = p.team.id " +
+                        "where tm.member.id = :userId " +
+                        "and p.status = 'FIXED' " +
+                        "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m') = :searchDate", Date.class)
+                .setParameter("userId", userId)
+                .setParameter("searchDate", searchDate)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/kuit/conet/jpa/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/HomeService.java
@@ -38,6 +38,6 @@ public class HomeService {
                 .map(tempDate -> Integer.parseInt(tempDate.split("-")[2]))
                 .toList();
 
-        return new MonthPlanResponse(planDates.size(), planDates)
+        return new MonthPlanResponse(planDates.size(), planDates);
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/HomeService.java
@@ -1,0 +1,43 @@
+package com.kuit.conet.jpa.service;
+
+import com.kuit.conet.dto.request.plan.HomePlanRequest;
+import com.kuit.conet.dto.response.plan.MonthPlanResponse;
+import com.kuit.conet.jpa.repository.HomeRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class HomeService {
+    private final HomeRepository homeRepository;
+
+    public MonthPlanResponse getPlanInMonth(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
+        Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
+
+        List<Date> dateList = homeRepository.getPlanInMonth(userId, planRequest.getSearchDate());
+
+        return getMonthPlanResponse(dateList);
+    }
+
+    // Response 만드는 걸 목적..? 으로 하는 메서드
+    private MonthPlanResponse getMonthPlanResponse(List<Date> dateList) {
+        List<Integer> planDates = dateList.stream()
+                .map(tempDate -> {
+                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+                    return sdf.format(tempDate);
+                }) // Date -> String
+                .map(tempDate -> Integer.parseInt(tempDate.split("-")[2]))
+                .toList();
+
+        return new MonthPlanResponse(planDates.size(), planDates)
+    }
+}

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -1,3 +1,4 @@
+/*
 package com.kuit.conet.service;
 
 import com.kuit.conet.dao.HomeDao;
@@ -52,4 +53,4 @@ public class HomeService {
 
         return new WaitingPlanResponse(plans.size(), plans);
     }
-}
+}*/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
     expired-date: ${ACCESSTOKEN_EXPIREDDATE}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 변경 사항
- URI 수정
`/home/month?searchDate=2023-12` 
-> `/home/plan/month?searchDate=2023-12`

- Plan의 Status Enum타입으로 수정
<img width="290" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/8d962fe8-5a0f-4254-82d5-77b6a266b7f5">


## API Test
<img width="1007" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/67258418-7b1e-4a2e-b0c8-60c32f44f0ab">
