### PR TITLE
fix: 모임 내 특정 날짜의 확정된 날짜 조회 query에 status 조회 추가

### DIFF
--- a/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
@@ -43,7 +43,7 @@ public class Plan {
     @Temporal(TemporalType.TIME)
     private Time fixedTime;
 
-    @ColumnDefault("WAITING")
+    @ColumnDefault("'WAITING'")
     @Enumerated(EnumType.STRING)
     private PlanStatus status;
 

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
@@ -1,15 +1,7 @@
 package com.kuit.conet.jpa.domain.plan;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public enum PlanStatus {
-    FIXED("FIXED"),   // 확정
-    WAITING("WAITING");   // 대기
+    FIXED,   // 확정
+    WAITING   // 대기
 
-    private String planStatus;
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -2,6 +2,7 @@ package com.kuit.conet.jpa.repository;
 
 import com.kuit.conet.domain.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.jpa.domain.plan.Plan;
+import com.kuit.conet.jpa.domain.plan.PlanStatus;
 import com.kuit.conet.jpa.domain.team.Team;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;
@@ -25,9 +26,11 @@ public class PlanRepository {
     public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, Date searchDate) {
         return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime)" +
                         "from Plan p join p.team t on t.id=:teamId " +
-                        "where p.fixedDate=:searchDate " +
+                        "where p.status=:status " +
+                        "and p.fixedDate=:searchDate " +
                         "order by p.fixedTime")
                 .setParameter("teamId", teamId)
+                .setParameter("status", PlanStatus.FIXED)
                 .setParameter("searchDate", searchDate)
                 .getResultList();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
     expired-date: ${ACCESSTOKEN_EXPIREDDATE}
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 변경 사항
PlanRepository의 `getFixedPlansOnDay()`에서 query의 where 절에 status 조회 추가
- status가 PlanStatus.WAITING과 일치하는지

```java
    public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, String searchDate) {
        return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime) " +
                "from Plan p join p.team t on t.id=:teamId " +
                "where p.status=:status " +
                "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m-%d')=:searchDate " +
                "order by p.fixedTime", TeamFixedPlanOnDay.class)
                .setParameter("teamId", teamId)
                .setParameter("status", PlanStatus.FIXED)
                .setParameter("searchDate", searchDate)
                .getResultList();
    }
```

<br>

## API Test
<img width="1552" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96233738/2f1e0f3b-6488-4e93-a6cc-266a9e7e3a5b">
