### PR TITLE
feat: 모임 내 특정 달의 약속이 존재하는 날짜 조회 기능 JPA 변환

### DIFF
--- a/src/main/java/com/kuit/conet/config/MvcConfig.java
+++ b/src/main/java/com/kuit/conet/config/MvcConfig.java
@@ -38,7 +38,7 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/bookmark/delete");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/plan/time");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/plan/user-time");
-        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/plan/month");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/plan/month");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/day");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/home/waiting");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/detail");

--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/plan")
+@RequestMapping("/home/plan")
 public class HomeController {
     private final HomeService homeService;
 

--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -30,10 +30,20 @@ public class PlanController {
      * - '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/day")
-    public BaseResponse<TeamPlanOnDayResponse> getPlanOnDay(@ModelAttribute @Valid TeamFixedPlanOnDayRequest planRequest) {
-        TeamPlanOnDayResponse response = planService.getPlanOnDay(planRequest);
+    public BaseResponse<TeamPlanOnDayResponse> getFixedPlanOnDay(@ModelAttribute @Valid TeamFixedPlanRequest request) {
+        TeamPlanOnDayResponse response = planService.getFixedPlanOnDay(request);
         return new BaseResponse<>(response);
     }
+
+    /**
+     * 모임 내 특정 달의 약속이 존재하는 날짜 조회 - 날짜 (dd)
+     */
+    @GetMapping("/month")
+    public BaseResponse<MonthPlanResponse> getFixedPlanInMonth(@ModelAttribute @Valid TeamFixedPlanRequest request) {
+        MonthPlanResponse response = planService.getFixedPlanInMonth(request);
+        return new BaseResponse<>(response);
+    }
+
 
 /*
     @PostMapping("/time")
@@ -59,16 +69,6 @@ public class PlanController {
         String response = planService.fixPlan(fixPlanRequest);
         return new BaseResponse<>(response);
     }
-
-    *//**
-     * 모임 내 특정 달의 약속 조회 - 날짜 (dd)
-     * *//*
-    @GetMapping("/month")
-    public BaseResponse<MonthPlanResponse> getPlanInMonth(@ModelAttribute @Valid TeamFixedPlanRequest planRequest) {
-        MonthPlanResponse response = planService.getPlanInMonth(planRequest);
-        return new BaseResponse<>(response);
-    }
-
 
     *//**
      * 모임 내 대기 중인 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 약속 명 / 모임 명

--- a/src/main/java/com/kuit/conet/dto/request/plan/TeamFixedPlanRequest.java
+++ b/src/main/java/com/kuit/conet/dto/request/plan/TeamFixedPlanRequest.java
@@ -10,10 +10,9 @@ import java.util.Date;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class TeamFixedPlanOnDayRequest {
+public class TeamFixedPlanRequest {
     private Long teamId;
-    @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private Date searchDate; // String to Date
-    // TODO: 프론트에 변경 사항 알리기
+    private String searchDate;
     // 특정 날짜 조회: "yyyy-MM-dd"
+    // 특정 달 조회: "yyyy-MM"
 }

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/Plan.java
@@ -43,7 +43,7 @@ public class Plan {
     @Temporal(TemporalType.TIME)
     private Time fixedTime;
 
-    @ColumnDefault("WAITING")
+    @ColumnDefault("'WAITING'")
     @Enumerated(EnumType.STRING)
     private PlanStatus status;
 

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/PlanStatus.java
@@ -1,15 +1,7 @@
 package com.kuit.conet.jpa.domain.plan;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public enum PlanStatus {
-    FIXED("FIXED"),   // 확정
-    WAITING("WAITING");   // 대기
+    FIXED,   // 확정
+    WAITING   // 대기
 
-    private String planStatus;
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.Date;
+import java.sql.Date;
 import java.util.List;
 
 @Repository
@@ -23,15 +23,27 @@ public class PlanRepository {
         return plan.getId();
     }
 
-    public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, Date searchDate) {
-        return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime)" +
-                        "from Plan p join p.team t on t.id=:teamId " +
-                        "where p.status=:status " +
-                        "and p.fixedDate=:searchDate " +
-                        "order by p.fixedTime")
+    public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, String searchDate) {
+        return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime) " +
+                "from Plan p join p.team t on t.id=:teamId " +
+                "where p.status=:status " +
+                "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m-%d')=:searchDate " +
+                "order by p.fixedTime", TeamFixedPlanOnDay.class)
                 .setParameter("teamId", teamId)
                 .setParameter("status", PlanStatus.FIXED)
                 .setParameter("searchDate", searchDate)
+                .getResultList();
+    }
+
+    public List<Date> getFixedPlansInMonth(Long teamId, String searchMonth) {
+        return em.createQuery("select distinct p.fixedDate " +
+                        "from Plan p join p.team t on t.id=:teamId " +
+                        "where p.status=:status " +
+                        "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m')=:searchMonth " +
+                        "order by p.fixedDate", Date.class)
+                .setParameter("teamId", teamId)
+                .setParameter("status", PlanStatus.FIXED)
+                .setParameter("searchMonth", searchMonth)
                 .getResultList();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -2,6 +2,7 @@ package com.kuit.conet.jpa.repository;
 
 import com.kuit.conet.domain.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.jpa.domain.plan.Plan;
+import com.kuit.conet.jpa.domain.plan.PlanStatus;
 import com.kuit.conet.jpa.domain.team.Team;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;
@@ -25,9 +26,11 @@ public class PlanRepository {
     public List<TeamFixedPlanOnDay> getFixedPlansOnDay(Long teamId, Date searchDate) {
         return em.createQuery("select new com.kuit.conet.domain.plan.TeamFixedPlanOnDay(p.id, p.name, p.fixedTime)" +
                         "from Plan p join p.team t on t.id=:teamId " +
-                        "where p.fixedDate=:searchDate " +
+                        "where p.status=:status " +
+                        "and p.fixedDate=:searchDate " +
                         "order by p.fixedTime")
                 .setParameter("teamId", teamId)
+                .setParameter("status", PlanStatus.FIXED)
                 .setParameter("searchDate", searchDate)
                 .getResultList();
     }

--- a/src/main/java/com/kuit/conet/jpa/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/HomeService.java
@@ -3,6 +3,7 @@ package com.kuit.conet.jpa.service;
 import com.kuit.conet.dto.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.jpa.repository.HomeRepository;
+import com.kuit.conet.utils.DateFormatter;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
-import java.text.SimpleDateFormat;
 import java.util.List;
 
 @Slf4j
@@ -22,21 +22,8 @@ public class HomeService {
 
     public MonthPlanResponse getPlanInMonth(HttpServletRequest httpRequest, HomePlanRequest planRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
-
-        List<Date> dateList = homeRepository.getPlanInMonth(userId, planRequest.getSearchDate());
-
-        return getMonthPlanResponse(dateList);
-    }
-
-    // Response 만드는 걸 목적..? 으로 하는 메서드
-    private MonthPlanResponse getMonthPlanResponse(List<Date> dateList) {
-        List<Integer> planDates = dateList.stream()
-                .map(tempDate -> {
-                    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-                    return sdf.format(tempDate);
-                }) // Date -> String
-                .map(tempDate -> Integer.parseInt(tempDate.split("-")[2]))
-                .toList();
+        List<Date> fixedPlansInMonth = homeRepository.getPlanInMonth(userId, planRequest.getSearchDate());
+        List<Integer> planDates = DateFormatter.datesToIntegerList(fixedPlansInMonth);
 
         return new MonthPlanResponse(planDates.size(), planDates);
     }

--- a/src/main/java/com/kuit/conet/jpa/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/PlanService.java
@@ -3,13 +3,15 @@ package com.kuit.conet.jpa.service;
 
 import com.kuit.conet.domain.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.dto.request.plan.CreatePlanRequest;
-import com.kuit.conet.dto.request.plan.TeamFixedPlanOnDayRequest;
+import com.kuit.conet.dto.request.plan.TeamFixedPlanRequest;
 import com.kuit.conet.dto.response.plan.CreatePlanResponse;
+import com.kuit.conet.dto.response.plan.MonthPlanResponse;
 import com.kuit.conet.dto.response.plan.TeamPlanOnDayResponse;
 import com.kuit.conet.jpa.domain.plan.Plan;
 import com.kuit.conet.jpa.domain.team.Team;
 import com.kuit.conet.jpa.repository.PlanRepository;
 import com.kuit.conet.jpa.repository.TeamRepository;
+import com.kuit.conet.utils.DateFormatter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -49,10 +49,18 @@ public class PlanService {
         return Date.valueOf(endDate);
     }
 
-    public TeamPlanOnDayResponse getPlanOnDay(TeamFixedPlanOnDayRequest request) {
+    public TeamPlanOnDayResponse getFixedPlanOnDay(TeamFixedPlanRequest request) {
         List<TeamFixedPlanOnDay> fixedPlansOnDay = planRepository.getFixedPlansOnDay(request.getTeamId(), request.getSearchDate());
 
         return new TeamPlanOnDayResponse(fixedPlansOnDay.size(), fixedPlansOnDay);
     }
+
+    public MonthPlanResponse getFixedPlanInMonth(TeamFixedPlanRequest request) {
+        List<Date> fixedPlansInMonth = planRepository.getFixedPlansInMonth(request.getTeamId(), request.getSearchDate());
+        List<Integer> planDates = DateFormatter.datesToIntegerList(fixedPlansInMonth);
+
+        return new MonthPlanResponse(planDates.size(), planDates);
+    }
+
 
 }

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -245,18 +245,6 @@ public class PlanService {
         return "약속 확정에 성공하였습니다.";
     }
 
-    public MonthPlanResponse getPlanInMonth(TeamFixedPlanRequest planRequest) {
-        List<Integer> planDates = new ArrayList<>();
-
-        List<String> dateList = planDao.getPlanInMonth(planRequest.getTeamId(), planRequest.getSearchDate()); // yyyy-MM
-        for(String tempDate : dateList) {
-            Integer date = Integer.parseInt(tempDate.split("-")[2]);
-            planDates.add(date);
-        }
-
-        return new MonthPlanResponse(planDates.size(), planDates);
-    }
-
     public TeamPlanOnDayResponse getPlanOnDay(TeamFixedPlanRequest planRequest) {
         List<TeamFixedPlanOnDay> plans = planDao.getPlanOnDay(planRequest.getTeamId(), planRequest.getSearchDate()); // yyyy-MM-dd
 

--- a/src/main/java/com/kuit/conet/utils/DateFormatter.java
+++ b/src/main/java/com/kuit/conet/utils/DateFormatter.java
@@ -1,0 +1,11 @@
+package com.kuit.conet.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.sql.Date;
+import java.util.List;
+
+@Component
+public class DateFormatter {
+
+}

--- a/src/main/java/com/kuit/conet/utils/DateFormatter.java
+++ b/src/main/java/com/kuit/conet/utils/DateFormatter.java
@@ -7,5 +7,13 @@ import java.util.List;
 
 @Component
 public class DateFormatter {
+    private static final int DATE_INDEX = 2;
+
+    public static List<Integer> datesToIntegerList(List<Date> dates) {
+        return dates.stream()
+                .map(Date::toString)
+                .map(date -> Integer.parseInt(date.split("-")[DATE_INDEX]))
+                .toList();
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,7 +54,7 @@ spring:
     expired-date: ${ACCESSTOKEN_EXPIREDDATE}
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 변경 사항
- URI 수정
`/team/plan/month?teamId={teamId}&searchDate={searchDate}`
-> `/plan/month?teamId={teamId}&searchDate={searchDate}`

### 참고 사항
PlanService와 HomeService에서 동일한 작업을 하는 메서드(yyyy-MM-dd 중 dd만 추출) 존재
= 중복 코드

`utils`/**`DateFormatter`** 클래스를 생성하여
각 service 단에서 `DateFormatter.datesToIntegerList(dateList);`와 같이 사용할 수 있도록 함

<br>

## API Test
<img width="1552" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96233738/2de95a6c-d4a6-4ad4-b39d-ea73569adbcf">
