### PR TITLE
feat: 모임 참가 api JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -30,11 +30,13 @@ public class TeamController {
         return new BaseResponse<CreateTeamResponse>(response);
     }
 
-/*    @PostMapping("/participate")
+    @PostMapping("/participate")
     public BaseResponse<ParticipateTeamResponse> participateTeam(@RequestBody @Valid ParticipateTeamRequest participateRequest, HttpServletRequest httpRequest) {
         ParticipateTeamResponse response = teamService.participateTeam(participateRequest, httpRequest);
         return new BaseResponse<ParticipateTeamResponse>(response);
     }
+
+    /*
 
     @PostMapping("/code")
     public BaseResponse<RegenerateCodeResponse> regenerateCode(@RequestBody @Valid TeamIdRequest request) {

--- a/src/main/java/com/kuit/conet/dto/response/team/ParticipateTeamResponse.java
+++ b/src/main/java/com/kuit/conet/dto/response/team/ParticipateTeamResponse.java
@@ -12,5 +12,5 @@ import lombok.ToString;
 public class ParticipateTeamResponse {
     private String userName;
     private String teamName;
-    private Boolean status;
+    private Integer status;
 }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.jpa.domain.team;
 
+import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.plan.Plan;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.springframework.data.annotation.CreatedBy;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -31,7 +33,7 @@ public class Team {
     private String inviteCode;
 
     @Temporal(TemporalType.TIMESTAMP)
-    private Date codeGeneratedTime;
+    private LocalDateTime codeGeneratedTime;
 
     @CreationTimestamp
     private Date createdAt;
@@ -39,11 +41,11 @@ public class Team {
     @OneToMany(mappedBy = "team") // 다대일 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<Plan> plans = new ArrayList<>();
 
-    @OneToMany(mappedBy = "team") // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder
-    public Team(String teamName, String inviteCode, Date codeGeneratedTime) {
+    public Team(String teamName, String inviteCode, LocalDateTime codeGeneratedTime) {
         this.name = teamName;
         this.imgUrl = "";
         this.inviteCode = inviteCode;
@@ -54,9 +56,7 @@ public class Team {
         this.imgUrl = imgUrl;
     }
 
-    public void addTeamMember(TeamMember teamMember) {
-        teamMembers.add(teamMember);
-    }
+
 
     public void addPlan(Plan plan) { plans.add(plan); }
 
@@ -64,5 +64,13 @@ public class Team {
         return plans.stream()
                 .filter(Plan::isFixed)
                 .toList();
+    }
+
+    //== 연관관계 편의 메서드 ==//
+    public void addTeamMember(Team team, Member user) {
+        TeamMember newTeamMember = new TeamMember(team,user);
+
+        team.teamMembers.add(newTeamMember);
+        newTeamMember.setTeam(team);
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
@@ -28,7 +28,9 @@ public class TeamMember {
     public TeamMember(Team team, Member member) {
         this.team = team;
         this.member = member;
+    }
 
-        team.addTeamMember(this);
+    public void setTeam(Team team) {
+        this.team=team;
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -29,4 +29,10 @@ public class TeamRepository {
                 .setParameter("inviteCode", inviteCode)
                 .getResultList();
     }
+
+    public boolean isExistInviteCode(String inviteCode) {
+        return em.createQuery("select count(t.id) > 0 from Team t where t.inviteCode=:inviteCode",Boolean.class)
+                .setParameter("inviteCode",inviteCode)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -37,6 +37,8 @@ public class TeamRepository {
     }
 
     public boolean isExistUser(Long id, Long userId) {
-
+        return em.createQuery("select count(tm.id) > 0 from Team t join t.teamMembers tm on tm.member.id=:userId",Boolean.class)
+                .setParameter("userId",userId)
+                .getSingleResult();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.jpa.repository;
 
+import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.team.Team;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -24,15 +24,19 @@ public class TeamRepository {
         return em.find(Team.class, id);
     }
 
-    public List<Team> findByInviteCode(String inviteCode) {
+    public Team findByInviteCode(String inviteCode) {
         return em.createQuery("select t from Team t where t.inviteCode=:inviteCode", Team.class)
                 .setParameter("inviteCode", inviteCode)
-                .getResultList();
+                .getSingleResult();
     }
 
     public boolean isExistInviteCode(String inviteCode) {
         return em.createQuery("select count(t.id) > 0 from Team t where t.inviteCode=:inviteCode",Boolean.class)
                 .setParameter("inviteCode",inviteCode)
                 .getSingleResult();
+    }
+
+    public boolean isExistUser(Long id, Long userId) {
+
     }
 }


### PR DESCRIPTION
## 변경 사항
- TeamRepository에 메소드 생성
  - findByInviteCode()
  - isExistInviteCode()
  - isExistUser()
- 연관관계 편의 메서드 생성
  - team이 있어야 teamMember가 존재가능 하므로 주종관계에서 team이 '주' -> team에서 연관관계 메서드
- 영속성 전이 설정
  - TeamMember를 List를 가진 Team이 부모 역할이므로 영속성 관리를 Team에서 하도록 설정
- Date -> LocalDateTime으로 수정 

## 참고 사항
존재 여부를 확인할 때, sql문에서는 exist 문법이 존재하지만 jpql에는 exist가 존재하지 않으므로, count(~) > 0으로 대체. springdata jpa를 사용하면 메서드명을 통해 간단한 존재 여부확인 메서드는 만들 수 있다고 한다.

## API Test
<img width="696" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/ca763f64-070d-4d6f-9f58-83397921eccb">