### PR TITLE
feat: 모임 리스트 조회 API JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -36,18 +36,18 @@ public class TeamController {
         return new BaseResponse<ParticipateTeamResponse>(response);
     }
 
+    @GetMapping
+    public BaseResponse<List<GetTeamResponse>> getTeam(HttpServletRequest httpRequest) {
+        List<GetTeamResponse> responses = teamService.getTeam(httpRequest);
+        return new BaseResponse<List<GetTeamResponse>>(responses);
+    }
+
     /*
 
     @PostMapping("/code")
     public BaseResponse<RegenerateCodeResponse> regenerateCode(@RequestBody @Valid TeamIdRequest request) {
         RegenerateCodeResponse response = teamService.regenerateCode(request);
         return new BaseResponse<>(response);
-    }
-
-    @GetMapping
-    public BaseResponse<List<GetTeamResponse>> getTeam(HttpServletRequest httpRequest) {
-        List<GetTeamResponse> responses = teamService.getTeam(httpRequest);
-        return new BaseResponse<List<GetTeamResponse>>(responses);
     }
 
     @PostMapping("/leave")

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -36,7 +36,7 @@ public class Team {
     private LocalDateTime codeGeneratedTime;
 
     @CreationTimestamp
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "team") // 다대일 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<Plan> plans = new ArrayList<>();
@@ -55,9 +55,6 @@ public class Team {
     public void updateImg(String imgUrl) {
         this.imgUrl = imgUrl;
     }
-
-
-
     public void addPlan(Plan plan) { plans.add(plan); }
 
     public List<Plan> getFixedPlans() {

--- a/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
@@ -22,12 +22,13 @@ public class TeamMember {
     @JoinColumn(name = "member_id") // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계의 주인
     private Member member;
 
-    @Column(columnDefinition = "integer default 0")
-    private Integer bookMark;
+    @Column(columnDefinition = "boolean default false")
+    private boolean bookMark;
 
     public TeamMember(Team team, Member member) {
         this.team = team;
         this.member = member;
+        this.bookMark = false;
     }
 
     public void setTeam(Team team) {

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -16,4 +16,11 @@ public class TeamMemberRepository {
         em.persist(teamMember);
         return teamMember.getId();
     }
+
+    public Boolean isBookmark(Long userId, Long teamId) {
+        return em.createQuery("select tm.bookMark from TeamMember tm where tm.team.id=:teamId and tm.member.id=:userId",boolean.class)
+                .setParameter("userId",userId)
+                .setParameter("teamId",teamId)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -42,4 +42,19 @@ public class TeamRepository {
                 .setParameter("userId",userId)
                 .getSingleResult();
     }
+
+    public List<Team> findByUserId(Long userId) {
+        return em.createQuery("select t from Team t join t.teamMembers tm on tm.member.id=:userId", Team.class)
+                .setParameter("userId", userId)
+                .getResultList();
+    }
+
+    public Long getMemberCount(Long id) {
+        return em.createQuery("select count(tm) from Team t join t.teamMembers tm on tm.team.id=:teamId",Long.class)
+                .setParameter("teamId",id)
+                .getSingleResult();
+    }
+
+    public Boolean isBookmark(Long userId, Long id) {
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -37,9 +37,10 @@ public class TeamRepository {
                 .getSingleResult();
     }
 
-    public boolean isExistUser(Long id, Long userId) {
-        return em.createQuery("select count(tm.id) > 0 from Team t join t.teamMembers tm on tm.member.id=:userId",Boolean.class)
+    public boolean isExistUser(Long teamId, Long userId) {
+        return em.createQuery("select count(tm.id) > 0 from Team t join t.teamMembers tm on t.id =:teamId and  tm.member.id=:userId",Boolean.class)
                 .setParameter("userId",userId)
+                .setParameter("teamId",teamId)
                 .getSingleResult();
     }
 
@@ -53,8 +54,5 @@ public class TeamRepository {
         return em.createQuery("select count(tm) from Team t join t.teamMembers tm on tm.team.id=:teamId",Long.class)
                 .setParameter("teamId",id)
                 .getSingleResult();
-    }
-
-    public Boolean isBookmark(Long userId, Long id) {
     }
 }


### PR DESCRIPTION
## 변경 사항
- TeamMember 엔티티의 bookmark 타입 integer->boolean으로 수정
- Team 엔티티의 createdAt 타입 Date->LocalDateTime으로 수정
- TeamRepository의 isExistUser 메서드 쿼리 오류 수정(on 절의 teamId 추가)
- TeamRepository에 getMemberCount 메서드 구현
- TeamMemberRepository에 isBookMark 메서드 구현

## 참고 사항
혹시 Date 타입으로 한 특별한 이유가 있는지..?

## API Test
<img width="675" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/1446f13c-dc07-416f-b29b-194e9e8d6b32">
