### PR TITLE
feat: 모임 탈퇴 api JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -42,18 +42,18 @@ public class TeamController {
         return new BaseResponse<List<GetTeamResponse>>(responses);
     }
 
+    @PostMapping("/leave")
+    public BaseResponse<String> leaveTeam(@RequestBody @Valid TeamIdRequest request, HttpServletRequest httpRequest) {
+        String response = teamService.leaveTeam(request, httpRequest);
+        return new BaseResponse<String>(response);
+    }
+
     /*
 
     @PostMapping("/code")
     public BaseResponse<RegenerateCodeResponse> regenerateCode(@RequestBody @Valid TeamIdRequest request) {
         RegenerateCodeResponse response = teamService.regenerateCode(request);
         return new BaseResponse<>(response);
-    }
-
-    @PostMapping("/leave")
-    public BaseResponse<String> leaveTeam(@RequestBody @Valid TeamIdRequest request, HttpServletRequest httpRequest) {
-        String response = teamService.leaveTeam(request, httpRequest);
-        return new BaseResponse<String>(response);
     }
 
     @PostMapping("/delete")

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -41,7 +41,7 @@ public class Team {
     @OneToMany(mappedBy = "team") // 다대일 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<Plan> plans = new ArrayList<>();
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -70,4 +70,8 @@ public class Team {
         team.teamMembers.add(newTeamMember);
         newTeamMember.setTeam(team);
     }
+
+    public void deleteMember(TeamMember teamMember) {
+        this.teamMembers.remove(teamMember);
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -23,4 +23,11 @@ public class TeamMemberRepository {
                 .setParameter("teamId",teamId)
                 .getSingleResult();
     }
+
+    public TeamMember findByTeamIdAndUserId(Long teamId, Long userId) {
+        return em.createQuery("select tm from TeamMember tm where tm.team.id=:teamId and tm.member.id=:userId", TeamMember.class)
+                .setParameter("teamId",teamId)
+                .setParameter("userId",userId)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -55,4 +55,5 @@ public class TeamRepository {
                 .setParameter("teamId",id)
                 .getSingleResult();
     }
+
 }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -2,6 +2,7 @@ package com.kuit.conet.jpa.service;
 
 import com.kuit.conet.common.exception.TeamException;
 import com.kuit.conet.dto.request.team.ParticipateTeamRequest;
+import com.kuit.conet.dto.request.team.TeamIdRequest;
 import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.team.TeamMember;
 import com.kuit.conet.jpa.domain.team.*;
@@ -159,6 +160,22 @@ public class TeamService {
         }
 
         return teamReturnResponses;
+    }
+
+    public String leaveTeam(TeamIdRequest teamIdRequest, HttpServletRequest httpRequest) {
+        Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
+        Team team = teamRepository.findById(teamIdRequest.getTeamId());
+        
+        // 모임 존재 여부 확인
+        if (team==null) {
+            throw new TeamException(NOT_FOUND_TEAM);
+        }
+
+        //변경 감지 이용
+        TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(team.getId(), userId);
+        team.deleteMember(teamMember);
+
+        return "모임 탈퇴에 성공하였습니다.";
     }
 
     //TODO: com.kuit.conet.service.TeamService 에 주석 처리된 코드 참고

--- a/src/main/java/com/kuit/conet/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/service/TeamService.java
@@ -62,8 +62,6 @@ public class TeamService {
         return new RegenerateCodeResponse(request.getTeamId(), newCode, codeDeadlineStr);
     }
 
-
-
     public String leaveTeam(TeamIdRequest teamIdRequest, HttpServletRequest httpRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
 


### PR DESCRIPTION
## 변경 사항
-Team 엔티티의 TeamMember 리스트에 고아 객체 설정!
  - Team의 remove(teamMember)만 해도 자식 객체도 같이 delete 적용된다! (delete 쿼리문이 나감)
-Team 엔티티에 deleteMember 메서드 추가
  - 변경 감지를 통해 DB에 적용
  - 고아 객체 설정으로 인한 자식 객체도 함께 삭제

## API Test
<img width="704" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/97e7dba5-d3b4-441b-8084-cbb82cc6ce13">

