### PR TITLE
feat: 모임 내 대기 중인 약속 조회 api JPA 변환 / 사이드바

### DIFF
--- a/src/main/java/com/kuit/conet/controller/HomeController.java
+++ b/src/main/java/com/kuit/conet/controller/HomeController.java
@@ -20,7 +20,8 @@ public class HomeController {
     private final HomeService homeService;
 
     /**
-     * 홈 특정 달의 확정 약속이 존재하는 날짜 조회 - 날짜 (dd)
+     * @apiNote 홈 특정 달의 확정 약속이 존재하는 날짜 조회 api
+     * / 날짜 (dd)
      * */
     @GetMapping("/month")
     public BaseResponse<PlanDateOnMonthResponse> getHomeFixedPlanInMonth(HttpServletRequest httpRequest, @ModelAttribute @Valid HomePlanRequest homeRequest) {
@@ -29,9 +30,11 @@ public class HomeController {
     }
 
     /**
-     * 홈 특정 날짜의 확정 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 모임 명 / 약속 명
-     * - '나'의 직접적인 참여 여부와 무관
+     * @apiNote 홈 특정 날짜의 확정 약속 조회 api
+     * / 날짜(yyyy. MM. dd) / 시각(HH:mm) / 모임 명 / 약속 명
+     * / '나'의 직접적인 참여 여부와 무관
      * */
+    //TODO: 내가 참여하는 약속만 조회
     @GetMapping("/day")
     public BaseResponse<HomePlanOnDayResponse> getHomeFixedPlanOnDay(HttpServletRequest httpRequest, @ModelAttribute @Valid HomePlanRequest homeRequest) {
         HomePlanOnDayResponse response = homeService.getHomeFixedPlanOnDay(httpRequest, homeRequest);
@@ -39,8 +42,9 @@ public class HomeController {
     }
 
     /**
-     * 홈 대기 중인 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 모임 명 / 약속 명
-     * - '나'의 직접적인 참여 여부와 무관
+     * @apiNote 홈 대기 중인 약속 조회 api
+     * / 날짜(yyyy. MM. dd) / 시각(HH:mm) / 모임 명 / 약속 명
+     * / '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/waiting")
     public BaseResponse<WaitingPlanResponse> getHomeWaitingPlan(HttpServletRequest httpRequest) {

--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -29,7 +29,7 @@ public class PlanController {
     }
 
     /**
-     * 모임 내 특정 날짜 확정 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm)
+     * @apiNote 모임 내 특정 날짜 확정 약속 조회 api
      * - '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/day")
@@ -39,7 +39,8 @@ public class PlanController {
     }
 
     /**
-     * 모임 내 특정 달의 약속이 존재하는 날짜 조회 - 날짜 (dd)
+     * @apiNote  모임 내 특정 달의 약속이 존재하는 날짜 조회 api
+     * 날짜 (dd)
      */
     @GetMapping("/month")
     public BaseResponse<PlanDateOnMonthResponse> getFixedPlanInMonth(@ModelAttribute @Valid TeamFixedPlanRequest planRequest) {

--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -44,6 +44,17 @@ public class PlanController {
         return new BaseResponse<>(response);
     }
 
+    /**
+     * @apiNote [사이드바] 모임 내 대기 중인 약속 조회 api
+     * / '나'의 직접적인 참여 여부와 무관
+     */
+    @GetMapping("/waiting")
+    public BaseResponse<WaitingPlanResponse> getWaitingPlan(@ModelAttribute @Valid TeamWaitingPlanRequest planRequest) {
+        WaitingPlanResponse response = planService.getTeamWaitingPlan(planRequest);
+        return new BaseResponse<>(response);
+    }
+
+
 /*
     @PostMapping("/time")
     public BaseResponse<String> registerTime(HttpServletRequest httpRequest, @RequestBody @Valid PossibleTimeRequest request) {

--- a/src/main/java/com/kuit/conet/controller/PlanController.java
+++ b/src/main/java/com/kuit/conet/controller/PlanController.java
@@ -1,11 +1,8 @@
 package com.kuit.conet.controller;
 
 import com.kuit.conet.common.response.BaseResponse;
-import com.kuit.conet.dto.web.request.plan.CreatePlanRequest;
-import com.kuit.conet.dto.web.request.plan.TeamFixedPlanRequest;
-import com.kuit.conet.dto.web.response.plan.CreatePlanResponse;
-import com.kuit.conet.dto.web.response.plan.PlanDateOnMonthResponse;
-import com.kuit.conet.dto.web.response.plan.TeamPlanOnDayResponse;
+import com.kuit.conet.dto.web.request.plan.*;
+import com.kuit.conet.dto.web.response.plan.*;
 import com.kuit.conet.jpa.service.PlanService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +27,7 @@ public class PlanController {
 
     /**
      * @apiNote 모임 내 특정 날짜 확정 약속 조회 api
-     * - '나'의 직접적인 참여 여부와 무관
+     * / '나'의 직접적인 참여 여부와 무관
      * */
     @GetMapping("/day")
     public BaseResponse<TeamPlanOnDayResponse> getFixedPlanOnDay(@ModelAttribute @Valid TeamFixedPlanRequest planRequest) {
@@ -40,14 +37,12 @@ public class PlanController {
 
     /**
      * @apiNote  모임 내 특정 달의 약속이 존재하는 날짜 조회 api
-     * 날짜 (dd)
      */
     @GetMapping("/month")
     public BaseResponse<PlanDateOnMonthResponse> getFixedPlanInMonth(@ModelAttribute @Valid TeamFixedPlanRequest planRequest) {
         PlanDateOnMonthResponse response = planService.getFixedPlanInMonth(planRequest);
         return new BaseResponse<>(response);
     }
-
 
 /*
     @PostMapping("/time")
@@ -71,17 +66,6 @@ public class PlanController {
     @PostMapping("/fix")
     public BaseResponse<String> fixPlan(@RequestBody @Valid FixPlanRequest fixPlanRequest) {
         String response = planService.fixPlan(fixPlanRequest);
-        return new BaseResponse<>(response);
-    }
-
-    *//**
-     * 모임 내 대기 중인 약속 조회 - 날짜(yyyy-MM-dd) / 시각(hh-mm) / 약속 명 / 모임 명
-     * - '나'의 직접적인 참여 여부와 무관
-     * - 모임 명은 필요 없지만 하나의 dto 를 공유하기 위하여 반환함
-     * *//*
-    @GetMapping("/waiting")
-    public BaseResponse<WaitingPlanResponse> getWaitingPlan(@ModelAttribute @Valid TeamWaitingPlanRequest planRequest) {
-        WaitingPlanResponse response = planService.getWaitingPlan(planRequest);
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/kuit/conet/dao/HomeDao.java
+++ b/src/main/java/com/kuit/conet/dao/HomeDao.java
@@ -2,7 +2,7 @@
 package com.kuit.conet.dao;
 
 import com.kuit.conet.domain.plan.HomeFixedPlanOnDay;
-import com.kuit.conet.domain.plan.WaitingPlan;
+import com.kuit.conet.dto.plan.WaitingPlan;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;

--- a/src/main/java/com/kuit/conet/domain/plan/HomeFixedPlanOnDay.java
+++ b/src/main/java/com/kuit/conet/domain/plan/HomeFixedPlanOnDay.java
@@ -1,19 +1,23 @@
 package com.kuit.conet.domain.plan;
 
+import com.kuit.conet.utils.DateFormatter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.sql.Time;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 public class HomeFixedPlanOnDay {
     private Long planId;
-    private Time time; // hh:mm:ss
+    private String time; // HH:mm
     private String teamName;
     private String planName;
+
+    public HomeFixedPlanOnDay(Long planId, Time time, String teamName, String planName) {
+        this.planId = planId;
+        this.time = DateFormatter.timeDeleteSecondsAndToString(time);
+        this.teamName = teamName;
+        this.planName = planName;
+    }
 }

--- a/src/main/java/com/kuit/conet/domain/plan/WaitingPlan.java
+++ b/src/main/java/com/kuit/conet/domain/plan/WaitingPlan.java
@@ -1,23 +1,23 @@
 package com.kuit.conet.domain.plan;
 
-import lombok.AllArgsConstructor;
+import com.kuit.conet.utils.DateFormatter;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.sql.Date;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 public class WaitingPlan {
     private Long planId;
-    private Date startDate; // yyyy-MM-dd
-    private Date endDate; // yyyy-MM-dd
+    private String startDate; // yyyy. MM. dd
+    private String endDate; // yyyy. MM. dd
     private String teamName;
     private String planName;
+
+    public WaitingPlan(Long planId, Date startDate, Date endDate, String teamName, String planName) {
+        this.planId = planId;
+        this.startDate = DateFormatter.dateToStringWithDot(startDate);
+        this.endDate = DateFormatter.dateToStringWithDot(endDate);
+        this.teamName = teamName;
+        this.planName = planName;
+    }
 }
-/**
- * 시작 날짜 / 마감 날짜 / 모임 명 / 약속 명
- * */

--- a/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
+++ b/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.dto.plan;
 
+import com.kuit.conet.utils.DateFormatter;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,11 +9,14 @@ import lombok.Setter;
 import java.sql.Time;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
 public class TeamFixedPlanOnDay {
     private Long planId;
     private String planName;
-    private Time time; // hh:mm:ss
+    private String time; // hh:mm
+
+    public TeamFixedPlanOnDay(Long planId, String planName, Time time) {
+        this.planId = planId;
+        this.planName = planName;
+        this.time = DateFormatter.timeDeleteSecondsAndToString(time);
+    }
 }

--- a/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
+++ b/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
@@ -12,7 +12,7 @@ import java.sql.Time;
 public class TeamFixedPlanOnDay {
     private Long planId;
     private String planName;
-    private String time; // hh:mm
+    private String time; // HH:mm
 
     public TeamFixedPlanOnDay(Long planId, String planName, Time time) {
         this.planId = planId;

--- a/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
+++ b/src/main/java/com/kuit/conet/dto/plan/TeamFixedPlanOnDay.java
@@ -14,5 +14,5 @@ import java.sql.Time;
 public class TeamFixedPlanOnDay {
     private Long planId;
     private String planName;
-    private Time time; // hh:mm
+    private Time time; // hh:mm:ss
 }

--- a/src/main/java/com/kuit/conet/dto/plan/WaitingPlan.java
+++ b/src/main/java/com/kuit/conet/dto/plan/WaitingPlan.java
@@ -1,4 +1,4 @@
-package com.kuit.conet.domain.plan;
+package com.kuit.conet.dto.plan;
 
 import com.kuit.conet.utils.DateFormatter;
 import lombok.Getter;

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/CreatePlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/CreatePlanResponse.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class CreatePlanResponse {

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/CreatePlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/CreatePlanResponse.java
@@ -7,7 +7,6 @@ import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
-@ToString
 public class CreatePlanResponse {
     private Long planId;
 }

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/HomePlanOnDayResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/HomePlanOnDayResponse.java
@@ -6,10 +6,7 @@ import lombok.*;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
-@ToString
 public class HomePlanOnDayResponse {
     int count;
     List<HomeFixedPlanOnDay> plans;

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/PlanDateOnMonthResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/PlanDateOnMonthResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-@ToString
 public class PlanDateOnMonthResponse {
     int count;
     List<Integer> dates;

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/PlanDateOnMonthResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/PlanDateOnMonthResponse.java
@@ -5,8 +5,6 @@ import lombok.*;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class PlanDateOnMonthResponse {

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/TeamPlanOnDayResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/TeamPlanOnDayResponse.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-@ToString
 public class TeamPlanOnDayResponse {
     int count;
     List<TeamFixedPlanOnDay> plans;

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/TeamPlanOnDayResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/TeamPlanOnDayResponse.java
@@ -6,8 +6,6 @@ import lombok.*;
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class TeamPlanOnDayResponse {

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/WaitingPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/WaitingPlanResponse.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-@ToString
 public class WaitingPlanResponse {
     private int count;
     private List<WaitingPlan> plans;

--- a/src/main/java/com/kuit/conet/dto/web/response/plan/WaitingPlanResponse.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/WaitingPlanResponse.java
@@ -1,13 +1,11 @@
 package com.kuit.conet.dto.web.response.plan;
 
-import com.kuit.conet.domain.plan.WaitingPlan;
+import com.kuit.conet.dto.plan.WaitingPlan;
 import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @ToString
 public class WaitingPlanResponse {

--- a/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
@@ -1,7 +1,7 @@
 package com.kuit.conet.jpa.repository;
 
 import com.kuit.conet.domain.plan.HomeFixedPlanOnDay;
-import com.kuit.conet.domain.plan.WaitingPlan;
+import com.kuit.conet.dto.plan.WaitingPlan;
 import com.kuit.conet.jpa.domain.plan.PlanStatus;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;
@@ -50,7 +50,7 @@ public class HomeRepository {
         // 모든 대기 중인 약속 중에서 p.status=WAITING
         // 시작 날짜가 오늘 이후 plan_start_period >= current_date();
 
-        return em.createQuery("select new com.kuit.conet.domain.plan.WaitingPlan(p.id, p.startPeriod, p.endPeriod, p.team.name, p.name) " +
+        return em.createQuery("select new com.kuit.conet.dto.plan.WaitingPlan(p.id, p.startPeriod, p.endPeriod, p.team.name, p.name) " +
                         "from TeamMember tm join Plan p on tm.team.id=p.team.id " +
                         "where tm.member.id=:userId " +
                         "and p.status=:status " +

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -49,9 +49,8 @@ public class PlanRepository {
 
     public List<WaitingPlan> getTeamWaitingPlan(Long teamId) {
         return em.createQuery("select new com.kuit.conet.dto.plan.WaitingPlan(p.id, p.startPeriod, p.endPeriod, p.team.name, p.name) " +
-                        "from TeamMember tm join Plan p on tm.team.id=p.team.id " +
-                        "where p.team.id=:teamId " +
-                        "and p.status=:status " +
+                        "from Plan p join p.team t on t.id=:teamId " +
+                        "where p.status=:status " +
                         "and p.startPeriod>=current_date() " +
                         "order by p.startPeriod", WaitingPlan.class)
                 .setParameter("teamId", teamId)

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.jpa.repository;
 
+import com.kuit.conet.dto.plan.WaitingPlan;
 import com.kuit.conet.dto.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.jpa.domain.plan.Plan;
 import com.kuit.conet.jpa.domain.plan.PlanStatus;
@@ -43,6 +44,18 @@ public class PlanRepository {
                 .setParameter("teamId", teamId)
                 .setParameter("status", PlanStatus.FIXED)
                 .setParameter("searchMonth", searchMonth)
+                .getResultList();
+    }
+
+    public List<WaitingPlan> getTeamWaitingPlan(Long teamId) {
+        return em.createQuery("select new com.kuit.conet.dto.plan.WaitingPlan(p.id, p.startPeriod, p.endPeriod, p.team.name, p.name) " +
+                        "from TeamMember tm join Plan p on tm.team.id=p.team.id " +
+                        "where p.team.id=:teamId " +
+                        "and p.status=:status " +
+                        "and p.startPeriod>=current_date() " +
+                        "order by p.startPeriod", WaitingPlan.class)
+                .setParameter("teamId", teamId)
+                .setParameter("status", PlanStatus.WAITING)
                 .getResultList();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/HomeService.java
@@ -1,7 +1,7 @@
 package com.kuit.conet.jpa.service;
 
 import com.kuit.conet.domain.plan.HomeFixedPlanOnDay;
-import com.kuit.conet.domain.plan.WaitingPlan;
+import com.kuit.conet.dto.plan.WaitingPlan;
 import com.kuit.conet.dto.web.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.web.response.plan.HomePlanOnDayResponse;
 import com.kuit.conet.dto.web.response.plan.PlanDateOnMonthResponse;

--- a/src/main/java/com/kuit/conet/jpa/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/PlanService.java
@@ -1,12 +1,15 @@
 package com.kuit.conet.jpa.service;
 
 
+import com.kuit.conet.dto.plan.WaitingPlan;
 import com.kuit.conet.dto.plan.TeamFixedPlanOnDay;
 import com.kuit.conet.dto.web.request.plan.CreatePlanRequest;
 import com.kuit.conet.dto.web.request.plan.TeamFixedPlanRequest;
+import com.kuit.conet.dto.web.request.plan.TeamWaitingPlanRequest;
 import com.kuit.conet.dto.web.response.plan.CreatePlanResponse;
 import com.kuit.conet.dto.web.response.plan.PlanDateOnMonthResponse;
 import com.kuit.conet.dto.web.response.plan.TeamPlanOnDayResponse;
+import com.kuit.conet.dto.web.response.plan.WaitingPlanResponse;
 import com.kuit.conet.jpa.domain.plan.Plan;
 import com.kuit.conet.jpa.domain.team.Team;
 import com.kuit.conet.jpa.repository.PlanRepository;
@@ -55,6 +58,12 @@ public class PlanService {
         List<Integer> planDates = DateFormatter.datesToIntegerList(fixedPlansInMonth);
 
         return new PlanDateOnMonthResponse(planDates.size(), planDates);
+    }
+
+    public WaitingPlanResponse getTeamWaitingPlan(TeamWaitingPlanRequest planRequest) {
+        List<WaitingPlan> teamWaitingPlans = planRepository.getTeamWaitingPlan(planRequest.getTeamId());
+
+        return new WaitingPlanResponse(teamWaitingPlans.size(), teamWaitingPlans);
     }
 
 

--- a/src/main/java/com/kuit/conet/service/HomeService.java
+++ b/src/main/java/com/kuit/conet/service/HomeService.java
@@ -3,7 +3,7 @@ package com.kuit.conet.service;
 
 import com.kuit.conet.dao.HomeDao;
 import com.kuit.conet.domain.plan.HomeFixedPlanOnDay;
-import com.kuit.conet.domain.plan.WaitingPlan;
+import com.kuit.conet.dto.plan.WaitingPlan;
 import com.kuit.conet.dto.request.plan.HomePlanRequest;
 import com.kuit.conet.dto.response.plan.HomePlanOnDayResponse;
 import com.kuit.conet.dto.response.plan.MonthPlanResponse;

--- a/src/main/java/com/kuit/conet/service/PlanService.java
+++ b/src/main/java/com/kuit/conet/service/PlanService.java
@@ -251,12 +251,6 @@ public class PlanService {
         return new TeamPlanOnDayResponse(plans.size(), plans);
     }
 
-    public WaitingPlanResponse getWaitingPlan(TeamWaitingPlanRequest planRequest) {
-        List<WaitingPlan> plans = planDao.getWaitingPlanInTeam(planRequest.getTeamId());
-
-        return new WaitingPlanResponse(plans.size(), plans);
-    }
-
     public PlanDetail getPlanDetail(PlanIdRequest planRequest) {
         //TODO: history 내용 삭제
         Long planId = planRequest.getPlanId();

--- a/src/main/java/com/kuit/conet/utils/DateFormatter.java
+++ b/src/main/java/com/kuit/conet/utils/DateFormatter.java
@@ -20,11 +20,13 @@ public class DateFormatter {
     }
 
     public static String dateToStringWithDot(Date date) {
+        // yyyy-MM-dd -> yyyy. MM. dd
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy. MM. dd");
         return dateFormat.format(date);
     }
 
     public static String timeDeleteSecondsAndToString(Time time) {
+        // HH:mm:ss -> HH:mm
         SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm");
         return dateFormat.format(time);
     }

--- a/src/main/java/com/kuit/conet/utils/DateFormatter.java
+++ b/src/main/java/com/kuit/conet/utils/DateFormatter.java
@@ -3,6 +3,8 @@ package com.kuit.conet.utils;
 import org.springframework.stereotype.Component;
 
 import java.sql.Date;
+import java.sql.Time;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
 @Component
@@ -15,6 +17,16 @@ public class DateFormatter {
                 .map(Date::toString)
                 .map(date -> Integer.parseInt(date.split(REGEX)[DATE_INDEX]))
                 .toList();
+    }
+
+    public static String dateToStringWithDot(Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy. MM. dd");
+        return dateFormat.format(date);
+    }
+
+    public static String timeDeleteSecondsAndToString(Time time) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm");
+        return dateFormat.format(time);
     }
 
 }


### PR DESCRIPTION
## 변경 사항
- URI 수정
`/team/plan/waiting?teamId={teamId}`
-> `/plan/waiting?teamId={teamId}`

request & response 수정 사항 없음

### 참고 사항
- 불필요한 `@Setter`, `@NoArgsConstructor`, `@ToString` 어노테이션 삭제
- 이전에 JPA로 변환한 api를 포함하여 프론트 팀원에게 제공하는 값 중 **날짜**와 **시간**에 해당하는 데이터의 포맷 변경 작업 추가
  - 날짜: `yyyy. MM. dd`
  - 시간: `HH:mm`

<br>

## API Test
<img width="1440" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96233738/37cf41b1-0955-47c5-b458-f372c39ff79f">
