### PR TITLE
feat: 모임 생성 API JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class TeamController {
     private final TeamService teamService;
 
-    @PostMapping("/")
+    @PostMapping
     public BaseResponse<CreateTeamResponse> createTeam(@RequestPart(value = "request") @Valid CreateTeamRequest createTeamRequest, HttpServletRequest httpRequest, @RequestParam(value = "file") MultipartFile file) {
         CreateTeamResponse response = teamService.createTeam(createTeamRequest, httpRequest, file);
         return new BaseResponse<CreateTeamResponse>(response);

--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class TeamController {
     private final TeamService teamService;
 
-    @PostMapping("/create")
+    @PostMapping("/")
     public BaseResponse<CreateTeamResponse> createTeam(@RequestPart(value = "request") @Valid CreateTeamRequest createTeamRequest, HttpServletRequest httpRequest, @RequestParam(value = "file") MultipartFile file) {
         CreateTeamResponse response = teamService.createTeam(createTeamRequest, httpRequest, file);
         return new BaseResponse<CreateTeamResponse>(response);

--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -27,7 +27,7 @@ public class TeamController {
     /**
      * @apiNote 모임 생성 api
      * */
-    @PostMapping("/create")
+    @PostMapping
     public BaseResponse<CreateTeamResponse> createTeam(@RequestPart(value = "request") @Valid CreateTeamRequest teamRequest, HttpServletRequest httpRequest, @RequestParam(value = "file") MultipartFile file) {
         CreateTeamResponse response = teamService.createTeam(teamRequest, httpRequest, file);
         return new BaseResponse<CreateTeamResponse>(response);

--- a/src/main/java/com/kuit/conet/dao/UserDao.java
+++ b/src/main/java/com/kuit/conet/dao/UserDao.java
@@ -25,7 +25,7 @@ public class UserDao {
     }
 
     public List<Long> findByPlatformAndPlatformId(Platform platform, String platformId) {
-        String sql = "select user_id from user where platform=:platform and platform_id=:platform_id and status=1";
+        String sql = "select member_id from member where platform=:platform and platform_id=:platform_id and status=1";
         Map<String, String> param = Map.of(
                 "platform", platform.getPlatform(),
                 "platform_id", platformId);
@@ -36,12 +36,12 @@ public class UserDao {
     }
 
     public User findById(Long userId) {
-        String sql = "select * from user where user_id=:user_id and status=1";
-        Map<String, Long> param = Map.of("user_id", userId);
+        String sql = "select * from member where member_id=:member_id and status=1";
+        Map<String, Long> param = Map.of("member_id", userId);
 
         RowMapper<User> mapper = (rs, rowNum) -> {
             User user = new User();
-            user.setUserId(rs.getLong("user_id"));
+            user.setUserId(rs.getLong("member_id"));
             user.setName(rs.getString("name"));
             user.setEmail(rs.getString("email"));
             user.setUserImgUrl(rs.getString("img_url"));
@@ -58,21 +58,21 @@ public class UserDao {
 
     public User save(User oauthUser) {
         // 회원가입 -> insert 한 후, 넣은 애 반환
-        String sql = "insert into user (email, platform, platform_id) values (:email, :platform, :platform_id)";
+        String sql = "insert into member (email, platform, platform_id) values (:email, :platform, :platform_id)";
         Map<String, String> param = Map.of("email", oauthUser.getEmail(),
                 "platform", oauthUser.getPlatform().toString(),
                 "platform_id", oauthUser.getPlatformId());
 
         jdbcTemplate.update(sql, param);
 
-        String returnSql = "select * from user where platform=:platform and platform_id=:platform_id";
+        String returnSql = "select * from member where platform=:platform and platform_id=:platform_id";
         Map<String, String> returnParam = Map.of(
                 "platform", oauthUser.getPlatform().toString(),
                 "platform_id", oauthUser.getPlatformId());
 
         RowMapper<User> returnMapper = (rs, rowNum) -> {
             User user = new User();
-            user.setUserId(rs.getLong("user_id"));
+            user.setUserId(rs.getLong("member_id"));
             user.setName(rs.getString("name"));
             user.setEmail(rs.getString("email"));
             user.setUserImgUrl(rs.getString("img_url"));
@@ -88,20 +88,20 @@ public class UserDao {
     }
 
     public User agreeTermAndPutName(String name, Boolean optionTerm, Long userId) {
-        String sql = "update user set name=:name, service_term=1, option_term=:option_term where user_id=:user_id and status=1";
+        String sql = "update member set name=:name, service_term=1, option_term=:option_term where member_id=:member_id and status=1";
         Map<String, Object> param = Map.of(
                 "name", name,
                 "option_term", optionTerm,
-                "user_id", userId);
+                "member_id", userId);
 
         jdbcTemplate.update(sql, param);
 
-        String returnSql = "select * from user where user_id=:user_id";
-        Map<String, Object> returnParam = Map.of("user_id", userId);
+        String returnSql = "select * from member where member_id=:member_id";
+        Map<String, Object> returnParam = Map.of("member_id", userId);
 
         RowMapper<User> returnMapper = (rs, rowNum) -> {
             User user = new User();
-            user.setUserId(rs.getLong("user_id"));
+            user.setUserId(rs.getLong("member_id"));
             user.setName(rs.getString("name"));
             user.setEmail(rs.getString("email"));
             user.setUserImgUrl(rs.getString("img_url"));
@@ -216,7 +216,7 @@ public class UserDao {
     public void updateOptionTerm(OptionTermRequest optionTermRequest, Long userId) {
         String sql = "update user set option_term=:option_term where user_id=:user_id and status=1";
         Map<String, Object> param = Map.of("option_term", optionTermRequest.getOption(),
-                                            "user_id", userId);
+                "user_id", userId);
         jdbcTemplate.update(sql, param);
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -42,7 +42,7 @@ public class Team {
     @OneToMany(mappedBy = "team") // 다대일 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<Plan> plans = new ArrayList<>();
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<TeamMember> teamMembers = new ArrayList<>();
 
     public void addPlan(Plan plan) { plans.add(plan); }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -71,24 +71,16 @@ public class Team {
     }
 
     //==생성 메서드==//
-    public static Team createTeam(String teamName, String inviteCode, Date codeGeneratedTime, Member teamCreator, MultipartFile file){
+    public static Team createTeam(String teamName, String inviteCode, Date codeGeneratedTime, Member teamCreator, String imgUrl){
         Team team = new Team();
         team.name=teamName;
         team.inviteCode=inviteCode;
         team.codeGeneratedTime=codeGeneratedTime;
+        team.imgUrl=imgUrl;
+
         TeamMember teamMember=TeamMember.createTeamMember(team,teamCreator);
         team.addTeamMember(teamMember);
 
-        String imgUrl = updateTeamImg(file, team.id);
-        team.imgUrl=imgUrl;
-
         return team;
-    }
-
-    private static String updateTeamImg(MultipartFile file, Long teamId) {
-        // 새로운 이미지 S3에 업로드
-        String fileName = StorageService.getFileName(file, StorageDomain.TEAM, teamId);
-        String imgUrl = StorageService.uploadToS3(file, fileName);
-        return imgUrl;
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
@@ -25,10 +25,13 @@ public class TeamMember {
     @Column(columnDefinition = "integer default 0")
     private Integer bookMark;
 
-    public TeamMember(Team team, Member member) {
-        this.team = team;
-        this.member = member;
 
-        team.addTeamMember(this);
+    //==생성 메서드==//
+    public static TeamMember createTeamMember(Team team, Member teamCreator) {
+        TeamMember teamMember = new TeamMember();
+        teamMember.member=teamCreator;
+        teamMember.team=team;
+
+        return teamMember;
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -54,7 +54,8 @@ public class TeamService {
                 .build();
         Long teamId = teamRepository.save(newTeam);
 
-        updateTeamImg(file, teamId, newTeam);
+        String imgUrl = updateTeamImg(file, teamId);
+        newTeam.updateImg(imgUrl);
 
         // teamMember 에 user 추가
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
@@ -65,13 +66,13 @@ public class TeamService {
         return new CreateTeamResponse(newTeam.getId(), newTeam.getInviteCode());
     }
 
-    private void updateTeamImg(MultipartFile file, Long teamId, Team newTeam) {
+    private String updateTeamImg(MultipartFile file, Long teamId) {
         // 새로운 이미지 S3에 업로드
         String fileName = storageService.getFileName(file, StorageDomain.TEAM, teamId);
         String imgUrl = storageService.uploadToS3(file, fileName);
 
         /*        StorageImgResponse response = teamDao.updateImg(teamId, imgUrl);*/
-        newTeam.updateImg(imgUrl);
+        return imgUrl;
     }
 
     public String generateInviteCode() {

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -49,15 +49,24 @@ public class TeamService {
         Timestamp codeGeneratedTime = Timestamp.valueOf(LocalDateTime.now());
 
         // 팀 만든 멤버 정보 추출
-        System.out.println((String) httpRequest.getAttribute("userId"));
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
         Member teamCreator = userRepository.findById(userId);
 
+        //이미지 s3 업로드
+        String imgUrl = updateTeamImg(file);
+
         // team 생성
-        Team newTeam = Team.createTeam(createTeamRequest.getTeamName(), inviteCode,codeGeneratedTime,teamCreator,file);
+        Team newTeam = Team.createTeam(createTeamRequest.getTeamName(), inviteCode,codeGeneratedTime,teamCreator,imgUrl);
         teamRepository.save(newTeam);
 
         return new CreateTeamResponse(newTeam.getId(), newTeam.getInviteCode());
+    }
+
+    private String updateTeamImg(MultipartFile file) {
+        // 새로운 이미지 S3에 업로드
+        String fileName = storageService.getFileName(file, StorageDomain.TEAM);
+        String imgUrl = storageService.uploadToS3(file, fileName);
+        return imgUrl;
     }
 
     public String generateInviteCode() {

--- a/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
+++ b/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
@@ -1,4 +1,11 @@
 package com.kuit.conet.jpa.service.validator;
 
+import com.kuit.conet.jpa.repository.TeamRepository;
+
 public class TeamValidator {
+
+    public static boolean validateDuplicateInviteCode(TeamRepository teamRepository, String inviteCode) {
+        //inviteCode 써도되면 true, 중복되면 false 반환
+        return !teamRepository.isExistInviteCode(inviteCode);
+    }
 }

--- a/src/main/java/com/kuit/conet/service/StorageService.java
+++ b/src/main/java/com/kuit/conet/service/StorageService.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
 import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.INVALID_FILE_EXTENSION;
@@ -26,13 +27,13 @@ import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.
 @RequiredArgsConstructor
 public class StorageService {
     @Value("${cloud.aws.s3.bucket}")
-    private static String bucketName;
+    private String bucketName;
     @Autowired
-    private static AmazonS3Client amazonS3Client;
+    private AmazonS3Client amazonS3Client;
     private static final String SPLITER = "/";
 
-    public static String getFileName(MultipartFile file, StorageDomain storage, Long id) {
-        String fileName = id + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
+    public static String getFileName(MultipartFile file, StorageDomain storage) {
+        String fileName = UUID.randomUUID() + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
         fileName = fileName.replace(" ", "-").replace(":", "-").replace(".", "-") + ".";
 
         String extension = null;
@@ -59,7 +60,7 @@ public class StorageService {
         return fileName;
     }
 
-    public static String uploadToS3(MultipartFile file, String fileName) {
+    public String uploadToS3(MultipartFile file, String fileName) {
         long size = file.getSize(); // 파일 크기
         ObjectMetadata objectMetaData = new ObjectMetadata();
         objectMetaData.setContentType(file.getContentType());

--- a/src/main/java/com/kuit/conet/service/StorageService.java
+++ b/src/main/java/com/kuit/conet/service/StorageService.java
@@ -26,12 +26,12 @@ import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.
 @RequiredArgsConstructor
 public class StorageService {
     @Value("${cloud.aws.s3.bucket}")
-    private String bucketName;
+    private static String bucketName;
     @Autowired
-    private AmazonS3Client amazonS3Client;
-    private final String SPLITER = "/";
+    private static AmazonS3Client amazonS3Client;
+    private static final String SPLITER = "/";
 
-    public String getFileName(MultipartFile file, StorageDomain storage, Long id) {
+    public static String getFileName(MultipartFile file, StorageDomain storage, Long id) {
         String fileName = id + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
         fileName = fileName.replace(" ", "-").replace(":", "-").replace(".", "-") + ".";
 
@@ -59,7 +59,7 @@ public class StorageService {
         return fileName;
     }
 
-    public String uploadToS3(MultipartFile file, String fileName) {
+    public static String uploadToS3(MultipartFile file, String fileName) {
         long size = file.getSize(); // 파일 크기
         ObjectMetadata objectMetaData = new ObjectMetadata();
         objectMetaData.setContentType(file.getContentType());

--- a/src/main/java/com/kuit/conet/service/StorageService.java
+++ b/src/main/java/com/kuit/conet/service/StorageService.java
@@ -31,9 +31,10 @@ public class StorageService {
     @Autowired
     private AmazonS3Client amazonS3Client;
     private static final String SPLITER = "/";
+    private static int sequenceNum = 1;
 
     public static String getFileName(MultipartFile file, StorageDomain storage) {
-        String fileName = UUID.randomUUID() + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
+        String fileName = sequenceNum + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
         fileName = fileName.replace(" ", "-").replace(":", "-").replace(".", "-") + ".";
 
         String extension = null;
@@ -57,6 +58,7 @@ public class StorageService {
         }
         fileName += extension;
 
+        sequenceNum++;
         return fileName;
     }
 

--- a/src/main/java/com/kuit/conet/service/StorageService.java
+++ b/src/main/java/com/kuit/conet/service/StorageService.java
@@ -33,7 +33,7 @@ public class StorageService {
     private static final String SPLITER = "/";
 
     public static String getFileName(MultipartFile file, StorageDomain storage) {
-        String fileName = UUID.randomUUID() + "-" + storage.getStorage() + "Image-" + LocalDateTime.now();
+        String fileName = storage.getStorage() + "Image-" +  + LocalDateTime.now();
         fileName = fileName.replace(" ", "-").replace(":", "-").replace(".", "-") + ".";
 
         String extension = null;

--- a/src/main/java/com/kuit/conet/service/UserService.java
+++ b/src/main/java/com/kuit/conet/service/UserService.java
@@ -55,7 +55,7 @@ public class UserService {
 
         // 저장할 파일명 만들기
         // 받은 파일이 이미지 타입이 아닌 경우에 대한 유효성 검사 진행
-        String fileName = storageService.getFileName(file, StorageDomain.USER, userId);
+        String fileName = storageService.getFileName(file, StorageDomain.USER);
 
         /*
         유저의 프로필 이미지가 기본 프로필 이미지인지 확인 -> 기본 이미지가 아니면 기존 이미지를 S3에서 이미지 삭제


### PR DESCRIPTION
#1 
## 변경 사항
- Team 도메인
  - codeGeneratedTime 타입을 LocalDateTime로 수정하면서 @Temporal 제거
  - updateImage 메소드 제거
  - Team 생성자 제거
  - 연관관계 편의 메서드 수정 (addTeamMember 인자 수정, 활용 1처럼 정석으로 수정)
  - 생성 메서드 - 생성 시, 만든 Member는 TeamMember에 바로 add
- TeamMember 도메인
  - 생성 메서드를 생성하면서 생성자 제거
  - bookmark 타입 boolean으로, 기본적으로 false 적용
- StorageService
  - getFileName 메서드에서 s3 이미지명 시퀀스값으로 수정
- TeamService
  - inviteCode 생성 메서드 추출
- TeamValidator
  - validateDuplicateInviteCode 메소드 생성

## API Test
<img width="721" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/fe8b0682-433e-4777-884c-44284b2940ee">
