### PR TITLE
팀 도메인 관련 리팩토링 

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -55,7 +55,7 @@ public class TeamController {
      * @apiNote 모임 탈퇴 api
      * */
     @PostMapping("/leave")
-    public BaseResponse<String> leaveTeam(@RequestBody @Valid TeamIdRequest teamRequest, HttpServletRequest httpRequest) {
+    public BaseResponse<String> leaveTeam(@RequestBody @Valid TeamIdRequestDTO teamRequest, HttpServletRequest httpRequest) {
         String response = teamService.leaveTeam(teamRequest, httpRequest);
         return new BaseResponse<String>(response);
     }

--- a/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/Team.java
@@ -18,7 +18,8 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "team_id")
     private Long id;
 
@@ -36,16 +37,20 @@ public class Team {
     @CreationTimestamp
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true) // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    // 다대다(다대일, 일대다) 양방향 연관 관계 / 연관 관계 주인의 반대편
     private List<Plan> plans = new ArrayList<>();
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true) // 다대다(다대일, 일대다) 단방향 연관 관계 / 연관 관계 주인의 반대편
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    // 다대다(다대일, 일대다) 단방향 연관 관계 / 연관 관계 주인의 반대편
     private List<TeamMember> teamMembers = new ArrayList<>();
 
-    public void addPlan(Plan plan) { plans.add(plan); }
+    public void addPlan(Plan plan) {
+        plans.add(plan);
+    }
 
     //==생성 메서드==//
-    public static Team createTeam(String teamName, String inviteCode, LocalDateTime codeGeneratedTime, Member teamCreator, String imgUrl){
+    public static Team createTeam(String teamName, String inviteCode, LocalDateTime codeGeneratedTime, Member teamCreator, String imgUrl) {
         Team team = new Team();
         team.name = teamName;
         team.inviteCode = inviteCode;

--- a/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/team/TeamMember.java
@@ -13,7 +13,8 @@ import org.hibernate.annotations.DynamicInsert;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 public class TeamMember {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "team_member_id")
     private Long id;
 

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanMemberRepository.java
@@ -7,11 +7,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class PlanMemberTimeRepository {
+public class PlanMemberRepository {
     private final EntityManager em;
-
     public int deleteOnPlan(Plan plan) {
-        int deletedPlanCount = em.createQuery("delete from PlanMemberTime pmt where pmt.plan=:plan")
+        int deletedPlanCount = em.createQuery("delete from PlanMember pm where pm.plan=:plan")
                 .setParameter("plan", plan)
                 .executeUpdate();
         em.flush();
@@ -19,8 +18,8 @@ public class PlanMemberTimeRepository {
     }
 
     public void deleteByTeamId(Long teamId) {
-        em.createQuery("delete from PlanMemberTime pmt where pmt.plan.id in " +
-                "(select p.id from Plan p where p.team.id=:teamId)")
+        em.createQuery("delete from PlanMember pm where pm.plan.id in " +
+                        "(select p.id from Plan p where p.team.id=:teamId)")
                 .setParameter("teamId",teamId)
                 .executeUpdate();
     }

--- a/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/PlanRepository.java
@@ -104,6 +104,12 @@ public class PlanRepository {
                 .getResultList();
     }
 
+    public void deletePlanByTeamId(Long teamId) {
+        em.createQuery("delete from Plan p where p.team.id=:teamId")
+                .setParameter("teamId",teamId)
+                .executeUpdate();
+    }
+
 //    public void fixPlan(Long planId, Date fixed_date, Time fixed_time, List<Long> userId) {
 //        String planSql = "update plan set fixed_date=:fixed_date, fixed_time=:fixed_time, status=2 where plan_id=:plan_id and status=1";
 //        Map<String, Object> planParam = Map.of("plan_id", planId,

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -56,19 +56,19 @@ public class TeamRepository {
 
     public Long getMemberCount(Long id) {
         return em.createQuery("select count(tm) from Team t join t.teamMembers tm on tm.team.id=:teamId", Long.class)
-                .setParameter("teamId",id)
+                .setParameter("teamId", id)
                 .getSingleResult();
     }
 
     public boolean isTeamMember(Team team, Long userId) {
         return em.createQuery("select count(tm)>0 from TeamMember  tm join tm.member on tm.member.id=:userId", Boolean.class)
-                .setParameter("userId",userId)
+                .setParameter("userId", userId)
                 .getSingleResult();
     }
 
     public String getTeamImgUrl(Long teamId) {
-        return em.createQuery("select t.imgUrl from Team t where t.id=:teamId",String.class)
-                .setParameter("teamId",teamId)
+        return em.createQuery("select t.imgUrl from Team t where t.id=:teamId", String.class)
+                .setParameter("teamId", teamId)
                 .getSingleResult();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -34,14 +34,12 @@ public class TeamRepository {
     }
 
     public boolean isExistInviteCode(String inviteCode) {
-        //todo count 함수 대신 exists 함수로
         return em.createQuery("select count(t.id) > 0 from Team t where t.inviteCode=:inviteCode", Boolean.class)
                 .setParameter("inviteCode", inviteCode)
                 .getSingleResult();
     }
 
     public boolean isExistUser(Long teamId, Long userId) {
-        //todo count 함수 대신 exists 함수로
         return em.createQuery("select count(tm.id) > 0 from Team t join t.teamMembers tm on t.id =:teamId and  tm.member.id=:userId", Boolean.class)
                 .setParameter("userId", userId)
                 .setParameter("teamId", teamId)
@@ -55,13 +53,14 @@ public class TeamRepository {
     }
 
     public Long getMemberCount(Long id) {
+        //todo 컬렉션 연관 필드 조인 관련 수정
         return em.createQuery("select count(tm) from Team t join t.teamMembers tm on tm.team.id=:teamId", Long.class)
                 .setParameter("teamId", id)
                 .getSingleResult();
     }
 
     public boolean isTeamMember(Team team, Long userId) {
-        return em.createQuery("select count(tm)>0 from TeamMember  tm join tm.member on tm.member.id=:userId", Boolean.class)
+        return em.createQuery("select count(tm)>0 from TeamMember tm join tm.member on tm.member.id=:userId", Boolean.class)
                 .setParameter("userId", userId)
                 .getSingleResult();
     }
@@ -70,5 +69,11 @@ public class TeamRepository {
         return em.createQuery("select t.imgUrl from Team t where t.id=:teamId", String.class)
                 .setParameter("teamId", teamId)
                 .getSingleResult();
+    }
+
+    public void deleteTeam(Long teamId) {
+        em.createQuery("delete from Team t where t.id=:teamId")
+                .setParameter("teamId", teamId)
+                .executeUpdate();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -60,8 +60,9 @@ public class TeamRepository {
     }
 
     public boolean isTeamMember(Team team, Long userId) {
-        return em.createQuery("select count(tm)>0 from TeamMember tm join tm.member on tm.member.id=:userId", Boolean.class)
+        return em.createQuery("select count(tm)>0 from Team t join t.teamMembers tm on tm.team=:team and tm.member.id=:userId", Boolean.class)
                 .setParameter("userId", userId)
+                .setParameter("team",team)
                 .getSingleResult();
     }
 

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -130,10 +130,9 @@ public class TeamService {
         //image 삭제
         deleteImage(teamId);
 
-//        teamMemberRepository.deleteTeamMemberByTeamId(teamId);
-//        Long deletedTeamId = teamRepository.deleteTeam(teamId);
-        teamRepository.remove(team);
-//        log.info(deletedTeamId.toString());
+        teamMemberRepository.deleteTeamMemberByTeamId(teamId);
+        teamRepository.deleteTeam(teamId);
+        //teamRepository.remove(team);
 
         return SUCCESS_DELETE_TEAM;
     }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -40,17 +40,18 @@ public class TeamService {
     private final UserRepository userRepository;
     private final TeamMemberRepository teamMemberRepository;
 
-    final int LEFT_LIMIT = 48;
-    final int RIGHT_LIMIT = 122;
-    final int TARGET_STRING_LENGTH = 8;
+    static final int LEFT_LIMIT = 48;
+    static final int RIGHT_LIMIT = 122;
+    static final int TARGET_STRING_LENGTH = 8;
+    static final int ASCII_NUMBER_NINE = 57;
+    static final int ASCII_UPPERCASE_A = 65;
+    static final int ASCII_UPPERCASE_Z = 90;
+    static final int ASCII_LOWERCASE_A = 97;
 
     final String SUCCESS_LEAVE_TEAM = "모임 탈퇴에 성공하였습니다.";
     final String SUCCESS_DELETE_TEAM = "모임 삭제에 성공하였습니다.";
 
     public CreateTeamResponseDTO createTeam(CreateTeamRequestDTO teamRequest, HttpServletRequest httpRequest, MultipartFile file) {
-        // 이미지 파일 확인
-        validateFileExisting(file);
-  
         // 초대 코드 생성 및 코드 중복 확인
         String inviteCode = getRandomInviteCode();
 
@@ -170,7 +171,7 @@ public class TeamService {
         Random random = new Random();
 
         String generatedString = random.ints(LEFT_LIMIT, RIGHT_LIMIT + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+                .filter(i -> (i <= ASCII_NUMBER_NINE || i >= ASCII_UPPERCASE_A) && (i <= ASCII_UPPERCASE_Z || i >= ASCII_LOWERCASE_A))
                 .limit(TARGET_STRING_LENGTH)
                 .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
                 .toString();
@@ -204,8 +205,4 @@ public class TeamService {
         return new GetTeamResponseDTO(team.getId(), team.getName(), team.getImgUrl(), teamRepository.getMemberCount(team.getId()),
                 false, teamMemberRepository.isBookmark(userId, team.getId()));
     }
-
-    //TODO: com.kuit.conet.service.TeamService 에 주석 처리된 코드 참고
-    //      -> 해당 메서드에 대하여 JPA 변환 완료하면 com.kuit.conet.service.TeamService에서 (주석)코드 삭제하기
-
 }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -80,7 +80,7 @@ public class TeamService {
         Team team = teamRepository.findByInviteCode(inviteCode);
 
         // 모임에 이미 존재하는 회원인지 확인
-        validateNewMemberInTeam(teamRepository,userId, team);
+        validateNewMemberInTeam(teamRepository, userId, team);
 
         // 초대 코드 생성 시간과 모임 참가 요청 시간 비교
         compareInviteCodeAndRequestTime(team);
@@ -98,16 +98,17 @@ public class TeamService {
 
         return generateTeamReturnResponse(teams, userId);
     }
+
     public String leaveTeam(TeamIdRequestDTO teamRequest, HttpServletRequest httpRequest) {
         Long userId = getUserIdFromHttpRequest(httpRequest);
- 
+
         Team team = teamRepository.findById(teamRequest.getTeamId());
 
         // 모임 존재 여부 확인
         validateTeamExisting(team);
 
         // 팀에 존재하는 멤버인지 확인
-        isTeamMember(teamRepository,team,userId);
+        isTeamMember(teamRepository, team, userId);
 
         //변경 감지 이용
         TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(team.getId(), userId);
@@ -124,7 +125,7 @@ public class TeamService {
         validateTeamExisting(team);
 
         // 모임 삭제 권한이 있는지 확인
-        isTeamMember(teamRepository,team,userId);
+        isTeamMember(teamRepository, team, userId);
 
         //image 삭제
         deleteImage(teamId);
@@ -140,7 +141,7 @@ public class TeamService {
     private void deleteImage(Long teamId) {
         String imgUrl = teamRepository.getTeamImgUrl(teamId);
 
-        if(!imgUrl.equals("")) {
+        if (!imgUrl.equals("")) {
             String deleteFileName = storageService.getFileNameFromUrl(imgUrl);
             storageService.deleteImage(deleteFileName);
         }
@@ -152,8 +153,8 @@ public class TeamService {
 
     private String getRandomInviteCode() {
         String inviteCode = generateInviteCode();
-        while(true){
-            if(validateDuplicateInviteCode(teamRepository, inviteCode))
+        while (true) {
+            if (validateDuplicateInviteCode(teamRepository, inviteCode))
                 break;
             inviteCode = generateInviteCode();
         }
@@ -181,7 +182,7 @@ public class TeamService {
 
     private String getInviteCodeFromRequest(ParticipateTeamRequestDTO teamRequest) {
         String inviteCode = teamRequest.getInviteCode();
-        validateInviteCodeExisting(teamRepository,inviteCode);
+        validateInviteCodeExisting(teamRepository, inviteCode);
         return inviteCode;
     }
 
@@ -189,12 +190,12 @@ public class TeamService {
         // 모임의 created_at 시간 비교해서 3일 안지났으면 isNew 값 true, 지났으면 false로 반환
         List<GetTeamResponseDTO> teamReturnResponses = new ArrayList<>();
 
-        for(Team team : teams) {
+        for (Team team : teams) {
             GetTeamResponseDTO teamResponse;
-            if(!isNewTeam(team)) {
-                teamResponse = generateTeamResponse(team,userId, false);
-            }else {
-                teamResponse = generateTeamResponse(team,userId, true);
+            if (!isNewTeam(team)) {
+                teamResponse = generateTeamResponse(team, userId, false);
+            } else {
+                teamResponse = generateTeamResponse(team, userId, true);
             }
             teamReturnResponses.add(teamResponse);
         }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -11,9 +11,7 @@ import com.kuit.conet.jpa.domain.team.*;
 
 import com.kuit.conet.jpa.domain.storage.StorageDomain;
 import com.kuit.conet.dto.web.request.team.CreateTeamRequestDTO;
-import com.kuit.conet.jpa.repository.TeamMemberRepository;
-import com.kuit.conet.jpa.repository.TeamRepository;
-import com.kuit.conet.jpa.repository.UserRepository;
+import com.kuit.conet.jpa.repository.*;
 import com.kuit.conet.service.StorageService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +36,9 @@ public class TeamService {
     private final StorageService storageService;
     private final TeamRepository teamRepository;
     private final UserRepository userRepository;
+    private final PlanRepository planRepository;
+    private final PlanMemberRepository planMemberRepository;
+    private final PlanMemberTimeRepository planMemberTimeRepository;
     private final TeamMemberRepository teamMemberRepository;
 
     static final int LEFT_LIMIT = 48;
@@ -130,7 +131,11 @@ public class TeamService {
         //image 삭제
         deleteImage(teamId);
 
+
         teamMemberRepository.deleteTeamMemberByTeamId(teamId);
+        planMemberTimeRepository.deleteByTeamId(teamId);
+        planMemberRepository.deleteByTeamId(teamId);
+        planRepository.deletePlanByTeamId(teamId);
         teamRepository.deleteTeam(teamId);
         //teamRepository.remove(team);
 

--- a/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
+++ b/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
@@ -32,7 +32,7 @@ public class TeamValidator {
         }
     }
 
-    public static void compareInviteCodeAndRequestTime(Team team){
+    public static void compareInviteCodeAndRequestTime(Team team) {
         LocalDateTime participateRequestTime = LocalDateTime.now();
         LocalDateTime generatedTime = team.getCodeGeneratedTime();
         LocalDateTime expirationDateTime = generatedTime.plusDays(1);
@@ -48,22 +48,22 @@ public class TeamValidator {
         }
     }
 
-    public static boolean isNewTeam(Team team){
-        log.info("{}",  team.getName());
+    public static boolean isNewTeam(Team team) {
+        log.info("{}", team.getName());
         LocalDateTime createdAt = team.getCreatedAt();
         LocalDateTime now = LocalDateTime.now();
 
         return !(now.minusDays(3).isAfter(createdAt));
     }
 
-    public static void validateTeamExisting(Team team){
-        if (team==null) {
+    public static void validateTeamExisting(Team team) {
+        if (team == null) {
             throw new TeamException(NOT_FOUND_TEAM);
         }
     }
 
-    public static void isTeamMember(TeamRepository teamRepository, Team team, Long userId){
-        if(!teamRepository.isTeamMember(team,userId)){
+    public static void isTeamMember(TeamRepository teamRepository, Team team, Long userId) {
+        if (!teamRepository.isTeamMember(team, userId)) {
             throw new TeamException(NOT_TEAM_MEMBER);
         }
     }


### PR DESCRIPTION
## 변경 사항
- 상수 추출 
- 코드 정렬
- delete문을 통한 team 삭제
  - PlanRepository, PlanMemberRepository, PlanMemberTimeRepository 에 서브쿼리를 통해 teamId 로 관련된 모든 데이터 삭제하도록 함

## API Test
리팩토링이라 테스트는 없어용