### PR TITLE
feat: 사용자 조회 api JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/com/kuit/conet/common/response/status/BaseExceptionResponseStatus.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum BaseExceptionResponseStatus implements ResponseStatus{
+public enum BaseExceptionResponseStatus implements ResponseStatus {
     /**
      * 1000: 요청 성공 (OK)
      */
@@ -43,23 +43,24 @@ public enum BaseExceptionResponseStatus implements ResponseStatus{
 
     /**
      * 5000: 회원 정보 오류
-     * */
-    INVALID_PLATFORM(5001, HttpStatus.BAD_REQUEST.value(),"플랫폼 정보가 올바르지 않습니다."),
-    NOT_FOUND_USER(5002, HttpStatus.BAD_REQUEST.value(),"존재하지 않는 사용자입니다."),
+     */
+    INVALID_PLATFORM(5001, HttpStatus.BAD_REQUEST.value(), "플랫폼 정보가 올바르지 않습니다."),
+    NOT_FOUND_USER(5002, HttpStatus.BAD_REQUEST.value(), "존재하지 않는 사용자입니다."),
+    INACTIVE_USER(5003, HttpStatus.BAD_REQUEST.value(), "활성화 상태가 아닌 사용자입니다."),
 
     /**
      * 5500: 모임(Team) 정보 오류
-     * */
+     */
 
-    NOT_FOUND_INVITE_CODE(5501, HttpStatus.NOT_FOUND.value(),"존재하지 않는 초대 코드입니다."),
-    EXPIRED_INVITE_CODE(5502, HttpStatus.BAD_REQUEST.value(),"초대 코드 유효 기간이 만료되었습니다."),
-    EXIST_USER_IN_TEAM(5503, HttpStatus.BAD_REQUEST.value(),"모임에 이미 참여 중입니다."),
-    USER_NOT_EXIST_IN_TEAM(5504, HttpStatus.BAD_REQUEST.value(),"모임에 참여하고 있지 않습니다."),
-    NOT_FOUND_TEAM(5505, HttpStatus.NOT_FOUND.value(),"존재하지 않는 모임입니다."),
-    NOT_TEAM_MEMBER(5507, HttpStatus.BAD_REQUEST.value(),"팀의 멤버가 아닙니다."),
+    NOT_FOUND_INVITE_CODE(5501, HttpStatus.NOT_FOUND.value(), "존재하지 않는 초대 코드입니다."),
+    EXPIRED_INVITE_CODE(5502, HttpStatus.BAD_REQUEST.value(), "초대 코드 유효 기간이 만료되었습니다."),
+    EXIST_USER_IN_TEAM(5503, HttpStatus.BAD_REQUEST.value(), "모임에 이미 참여 중입니다."),
+    USER_NOT_EXIST_IN_TEAM(5504, HttpStatus.BAD_REQUEST.value(), "모임에 참여하고 있지 않습니다."),
+    NOT_FOUND_TEAM(5505, HttpStatus.NOT_FOUND.value(), "존재하지 않는 모임입니다."),
+    NOT_TEAM_MEMBER(5507, HttpStatus.BAD_REQUEST.value(), "팀의 멤버가 아닙니다."),
     /**
      * 6000: 약속(Plan) 정보 오류
-     * */
+     */
     NOT_WAITING_PLAN(6000, HttpStatus.BAD_REQUEST.value(), "대기 중인 약속 아닙니다."),
     NOT_FIXED_PLAN(6001, HttpStatus.BAD_REQUEST.value(), "확정된 약속이 아닙니다."),
     NOT_PAST_PLAN(6002, HttpStatus.BAD_REQUEST.value(), "지난 약속이 아닙니다."),

--- a/src/main/java/com/kuit/conet/controller/MemberController.java
+++ b/src/main/java/com/kuit/conet/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.kuit.conet.annotation.UserId;
 import com.kuit.conet.common.response.BaseResponse;
 import com.kuit.conet.dto.web.request.member.NameRequestDTO;
 import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
+import com.kuit.conet.dto.web.response.member.MemberResponseDTO;
 import com.kuit.conet.jpa.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +23,13 @@ public class MemberController {
     public BaseResponse<String> userDelete(@UserId Long userId) {
         memberService.userDelete(userId);
         return new BaseResponse<>("유저 탈퇴에 성공하였습니다.");
-    }
+    }*/
 
     @GetMapping
-    public BaseResponse<UserResponseDTO> getUser(@UserId Long userId) {
-        UserResponseDTO response = memberService.getUser(userId);
+    public BaseResponse<MemberResponseDTO> getUser(@UserId Long userId) {
+        MemberResponseDTO response = memberService.getUser(userId);
         return new BaseResponse<>(response);
-    }*/
+    }
 
     @PostMapping("/image")
     public BaseResponse<StorageImgResponseDTO> updateImg(@UserId Long userId, @RequestParam(value = "file") MultipartFile file) {

--- a/src/main/java/com/kuit/conet/dao/UserDao.java
+++ b/src/main/java/com/kuit/conet/dao/UserDao.java
@@ -2,8 +2,6 @@ package com.kuit.conet.dao;
 
 import com.kuit.conet.domain.user.User;
 import com.kuit.conet.dto.web.request.auth.OptionTermRequestDTO;
-import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
-import com.kuit.conet.dto.web.response.member.MemberResponseDTO;
 import com.kuit.conet.jpa.domain.auth.Platform;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.RowMapper;
@@ -129,7 +127,7 @@ public class UserDao {
         jdbcTemplate.update(sql, param);
     }
 
-    public MemberResponseDTO getUser(Long userId) {
+    /*public MemberResponseDTO getUser(Long userId) {
         String sql = "select name, email, img_url, platform from user where user_id=:user_id and status=1";
         Map<String, Object> param = Map.of("user_id", userId);
 
@@ -204,7 +202,7 @@ public class UserDao {
         Map<String, Object> param = Map.of("user_id", userId);
 
         return jdbcTemplate.queryForObject(sql, param, String.class);
-    }
+    }*/
 
     public Boolean getOptionTerm(Long userId) {
         String sql = "select option_term from user where user_id=:user_id and status=1";

--- a/src/main/java/com/kuit/conet/dto/web/response/member/MemberResponseDTO.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/member/MemberResponseDTO.java
@@ -1,6 +1,6 @@
 package com.kuit.conet.dto.web.response.member;
 
-import com.kuit.conet.jpa.domain.auth.Platform;
+import com.kuit.conet.jpa.domain.member.Member;
 import lombok.*;
 
 @Getter
@@ -12,5 +12,12 @@ public class MemberResponseDTO {
     private String name;
     private String email;
     private String userImgUrl;
-    private Platform platform;
+    private String platform;
+
+    public MemberResponseDTO(Member member) {
+        this.name = member.getName();
+        this.email = member.getEmail();
+        this.userImgUrl = member.getImgUrl();
+        this.platform = member.getPlatform();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/MemberService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/MemberService.java
@@ -2,16 +2,19 @@ package com.kuit.conet.jpa.service;
 
 import com.kuit.conet.dto.web.request.member.NameRequestDTO;
 import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
+import com.kuit.conet.dto.web.response.member.MemberResponseDTO;
 import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.storage.StorageDomain;
 import com.kuit.conet.jpa.repository.MemberRepository;
 import com.kuit.conet.service.StorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import static com.kuit.conet.jpa.service.validator.MemberValidator.validateActiveMember;
 import static com.kuit.conet.jpa.service.validator.MemberValidator.validateMemberExisting;
 import static com.kuit.conet.service.StorageService.getFileName;
 
@@ -22,10 +25,13 @@ import static com.kuit.conet.service.StorageService.getFileName;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final StorageService storageService;
+    @Value("${spring.user.default-image}")
+    private String defaultImg;
 
     public StorageImgResponseDTO updateImg(Long userId, MultipartFile file) {
         Member member = memberRepository.findById(userId);
         validateMemberExisting(member);
+        validateActiveMember(member);
 
         storageService.deletePreviousImage(userId);
 
@@ -39,11 +45,27 @@ public class MemberService {
     }
 
     public void updateName(Long userId, NameRequestDTO nameRequest) {
-        System.out.println("service " + userId);
         Member member = memberRepository.findById(userId);
         validateMemberExisting(member);
+        validateActiveMember(member);
 
         member.updateName(nameRequest.getName());
+    }
+
+    public MemberResponseDTO getUser(Long userId) {
+        Member member = memberRepository.findById(userId);
+        validateMemberExisting(member);
+        validateActiveMember(member);
+
+        String fileName = storageService.getFileNameFromUrl(member.getImgUrl());
+        // S3에 없는 객체에 대한 유효성 검사
+        if (!storageService.isExistImage(fileName)) {
+            log.warn("S3 버킷에 존재하지 않는 이미지입니다. 기본 이미지로 변경하겠습니다.");
+            // 변경감지로 update
+            member.updateImgUrl(defaultImg);
+        }
+
+        return new MemberResponseDTO(member);
     }
 
 }

--- a/src/main/java/com/kuit/conet/jpa/service/validator/MemberValidator.java
+++ b/src/main/java/com/kuit/conet/jpa/service/validator/MemberValidator.java
@@ -2,15 +2,23 @@ package com.kuit.conet.jpa.service.validator;
 
 import com.kuit.conet.common.exception.UserException;
 import com.kuit.conet.jpa.domain.member.Member;
+import com.kuit.conet.jpa.domain.member.MemberStatus;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.INACTIVE_USER;
 import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.NOT_FOUND_USER;
 
 @Slf4j
 public class MemberValidator {
-    public static void validateMemberExisting(Member member){
+    public static void validateMemberExisting(Member member) {
         if (member == null) {
             throw new UserException(NOT_FOUND_USER);
+        }
+    }
+
+    public static void validateActiveMember(Member member) {
+        if (!(member.getStatus() == MemberStatus.ACTIVE)) {
+            throw new UserException(INACTIVE_USER);
         }
     }
 }

--- a/src/main/java/com/kuit/conet/service/UserService.java
+++ b/src/main/java/com/kuit/conet/service/UserService.java
@@ -1,3 +1,4 @@
+/*
 package com.kuit.conet.service;
 
 import com.kuit.conet.common.exception.UserException;
@@ -52,9 +53,11 @@ public class UserService {
         // 받은 파일이 이미지 타입이 아닌 경우에 대한 유효성 검사 진행
         String fileName = storageService.getFileName(file, StorageDomain.USER);
 
-        /*
+        */
+/*
         유저의 프로필 이미지가 기본 프로필 이미지인지 확인 -> 기본 이미지가 아니면 기존 이미지를 S3에서 이미지 삭제
-        S3 버킷에 존재하지 않는 객체인 경우 삭제를 생략 */
+        S3 버킷에 존재하지 않는 객체인 경우 삭제를 생략 *//*
+
         String imgUrl = userDao.getUserImgUrl(userId);
         String deleteFileName = storageService.getFileNameFromUrl(imgUrl);
         if (!userDao.isDefaultImage(userId)) {
@@ -79,4 +82,4 @@ public class UserService {
             throw new UserException(NOT_FOUND_USER);
         }
     }
-}
+}*/


### PR DESCRIPTION
## 변경 사항
- validateActiveMember 메서드로 활성화 상태의 사용자인지 확인
- MemberResponseDTO 생성메서드 구현

### URI 수정

### Request Body 필드명 수정

### Response 수정

<br>

## API Test
<img width="1040" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/e58d6852-0fe6-4447-a1e7-78dafaa65f29">