### PR TITLE
모임 구성원 조회 API JPA로 변환

### DIFF
--- a/src/main/java/com/kuit/conet/config/MvcConfig.java
+++ b/src/main/java/com/kuit/conet/config/MvcConfig.java
@@ -1,7 +1,7 @@
 package com.kuit.conet.config;
 
-import com.kuit.conet.utils.auth.BearerAuthInterceptor;
 import com.kuit.conet.utils.StringToEnumConverter;
+import com.kuit.conet.utils.auth.BearerAuthInterceptor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +41,7 @@ public class MvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/user/delete");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/{teamId}");
+        registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/{teamId}/members");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/create");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/join");
         registry.addInterceptor(bearerAuthInterceptor).addPathPatterns("/team/leave");

--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -6,6 +6,7 @@ import com.kuit.conet.dto.web.request.team.CreateTeamRequestDTO;
 import com.kuit.conet.dto.web.request.team.JoinTeamRequestDTO;
 import com.kuit.conet.dto.web.request.team.TeamIdRequestDTO;
 import com.kuit.conet.dto.web.response.team.CreateTeamResponseDTO;
+import com.kuit.conet.dto.web.response.team.GetTeamMemberResponseDTO;
 import com.kuit.conet.dto.web.response.team.GetTeamResponseDTO;
 import com.kuit.conet.dto.web.response.team.JoinTeamResponseDTO;
 import com.kuit.conet.jpa.service.TeamService;
@@ -69,6 +70,15 @@ public class TeamController {
         return new BaseResponse<String>(response);
     }
 
+    /**
+     * @apiNote 모임 멤버 조회 api
+     */
+    @GetMapping("/members")
+    public BaseResponse<List<GetTeamMemberResponseDTO>> getTeamMembers(@ModelAttribute @Valid TeamIdRequestDTO teamRequest) {
+        List<GetTeamMemberResponseDTO> response = teamService.getTeamMembers(teamRequest);
+        return new BaseResponse<>(response);
+    }
+
     /*
 
     @PostMapping("/code")
@@ -82,12 +92,6 @@ public class TeamController {
     public BaseResponse<StorageImgResponse> updateTeam(@RequestPart(value = "request") @Valid UpdateTeamRequest updateTeamRequest, @RequestParam(value = "file") MultipartFile file) {
         StorageImgResponse response = teamService.updateTeam(updateTeamRequest, file);
         return new BaseResponse<StorageImgResponse>(response);
-    }
-
-    @GetMapping("/members")
-    public BaseResponse<List<GetTeamMemberResponse>> getTeamMembers(@ModelAttribute @Valid TeamIdRequest request) {
-        List<GetTeamMemberResponse> response = teamService.getTeamMembers(request);
-        return new BaseResponse<>(response);
     }
 
     @PostMapping("/bookmark")

--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -71,11 +71,11 @@ public class TeamController {
     }
 
     /**
-     * @apiNote 모임 멤버 조회 api
+     * @apiNote 모임 구성원 조회 api
      */
-    @GetMapping("/members")
-    public BaseResponse<List<GetTeamMemberResponseDTO>> getTeamMembers(@ModelAttribute @Valid TeamIdRequestDTO teamRequest) {
-        List<GetTeamMemberResponseDTO> response = teamService.getTeamMembers(teamRequest);
+    @GetMapping("/team/{teamId}/members")
+    public BaseResponse<List<GetTeamMemberResponseDTO>> getTeamMembers(@PathVariable @Valid Long teamId) {
+        List<GetTeamMemberResponseDTO> response = teamService.getTeamMembers(teamId);
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -73,9 +73,9 @@ public class TeamController {
     /**
      * @apiNote 모임 구성원 조회 api
      */
-    @GetMapping("/team/{teamId}/members")
-    public BaseResponse<List<GetTeamMemberResponseDTO>> getTeamMembers(@PathVariable @Valid Long teamId) {
-        List<GetTeamMemberResponseDTO> response = teamService.getTeamMembers(teamId);
+    @GetMapping("/{teamId}/members")
+    public BaseResponse<List<GetTeamMemberResponseDTO>> getTeamMembers(@PathVariable @Valid Long teamId, @UserId Long userId) {
+        List<GetTeamMemberResponseDTO> response = teamService.getTeamMembers(teamId, userId);
         return new BaseResponse<>(response);
     }
 

--- a/src/main/java/com/kuit/conet/jpa/repository/MemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.kuit.conet.jpa.repository;
 
 import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
+import com.kuit.conet.dto.web.response.team.GetTeamMemberResponseDTO;
 import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.member.MemberStatus;
 import jakarta.persistence.EntityManager;
@@ -8,6 +9,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -41,5 +44,10 @@ public class MemberRepository {
                 .getSingleResult();
     }
 
-
+    public List<GetTeamMemberResponseDTO> getMembersByTeamId(Long teamId) {
+        return em.createQuery("select new com.kuit.conet.dto.web.response.team.GetTeamMemberResponseDTO(m.id,m.name,m.imgUrl) " +
+                        "from TeamMember tm join tm.member m where tm.team.id=:teamId")
+                .setParameter("teamId", teamId)
+                .getResultList();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 @RequiredArgsConstructor
 @Getter
@@ -33,15 +31,9 @@ public class TeamMemberRepository {
                 .getSingleResult();
     }
 
-    public List<TeamMember> findByTeamId(Long teamId) {
-        return em.createQuery("select tm from TeamMember tm where tm.team.id=:teamId",TeamMember.class)
-                .setParameter("teamId",teamId)
-                .getResultList();
-    }
-
     public void deleteTeamMemberByTeamId(Long teamId) {
         em.createQuery("delete from TeamMember tm where tm.team.id=:teamId")
-                .setParameter("teamId",teamId)
+                .setParameter("teamId", teamId)
                 .executeUpdate();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -130,8 +130,8 @@ public class TeamService {
         return SUCCESS_DELETE_TEAM;
     }
 
-    public List<GetTeamMemberResponseDTO> getTeamMembers(TeamIdRequestDTO teamRequest) {
-        return memberRepository.getMembersByTeamId(teamRequest.getTeamId());
+    public List<GetTeamMemberResponseDTO> getTeamMembers(Long teamId) {
+        return memberRepository.getMembersByTeamId(teamId);
     }
 
     private void deleteImage(Long teamId) {

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -4,6 +4,7 @@ import com.kuit.conet.dto.web.request.team.CreateTeamRequestDTO;
 import com.kuit.conet.dto.web.request.team.JoinTeamRequestDTO;
 import com.kuit.conet.dto.web.request.team.TeamIdRequestDTO;
 import com.kuit.conet.dto.web.response.team.CreateTeamResponseDTO;
+import com.kuit.conet.dto.web.response.team.GetTeamMemberResponseDTO;
 import com.kuit.conet.dto.web.response.team.GetTeamResponseDTO;
 import com.kuit.conet.dto.web.response.team.JoinTeamResponseDTO;
 import com.kuit.conet.jpa.domain.member.Member;
@@ -120,15 +121,17 @@ public class TeamService {
         //image 삭제
         deleteImage(teamId);
 
-
         teamMemberRepository.deleteTeamMemberByTeamId(teamId);
         planMemberTimeRepository.deleteByTeamId(teamId);
         planMemberRepository.deleteByTeamId(teamId);
         planRepository.deletePlanByTeamId(teamId);
         teamRepository.deleteTeam(teamId);
-        //teamRepository.remove(team);
 
         return SUCCESS_DELETE_TEAM;
+    }
+
+    public List<GetTeamMemberResponseDTO> getTeamMembers(TeamIdRequestDTO teamRequest) {
+        return memberRepository.getMembersByTeamId(teamRequest.getTeamId());
     }
 
     private void deleteImage(Long teamId) {

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -130,7 +130,11 @@ public class TeamService {
         return SUCCESS_DELETE_TEAM;
     }
 
-    public List<GetTeamMemberResponseDTO> getTeamMembers(Long teamId) {
+    public List<GetTeamMemberResponseDTO> getTeamMembers(Long teamId, Long userId) {
+        //팀 구성원인지 확인
+        Team team = teamRepository.findById(teamId);
+        //isTeamMember(teamRepository, team, userId);
+
         return memberRepository.getMembersByTeamId(teamId);
     }
 

--- a/src/main/java/com/kuit/conet/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/service/TeamService.java
@@ -116,10 +116,6 @@ public class TeamService {
         return response;
     }
 
-    public List<GetTeamMemberResponse> getTeamMembers(TeamIdRequest teamIdRequest) {
-        return teamDao.getTeamMembers(teamIdRequest.getTeamId());
-    }
-
     public void bookmarkTeam(HttpServletRequest httpRequest, TeamIdRequest request) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
         Long teamId = request.getTeamId();


### PR DESCRIPTION
## 변경 사항
- uri 수정
  - team/members -> team/{teamId}/members
- MemberRepository에 getMembersByTeamId 추가
- 팀 구성원인지 확인하는 로직 추가(보류)
  - 근데 userId 값이 null로 들어와서 잠깐 보류요

## API Test
<img width="575" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/6c5c7a5f-fa86-4185-b891-9a8e82ddcc72">
