### PR TITLE
모임 상세 조회 api JPA 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/TeamController.java
+++ b/src/main/java/com/kuit/conet/controller/TeamController.java
@@ -79,6 +79,15 @@ public class TeamController {
         return new BaseResponse<>(response);
     }
 
+    /**
+     * @apiNote 모임 상세 조회 api
+     */
+    @GetMapping("/{teamId}")
+    public BaseResponse<GetTeamResponseDTO> getTeamDetail(@PathVariable Long teamId, @UserId Long userId) {
+        GetTeamResponseDTO response = teamService.getTeamDetail(teamId, userId);
+        return new BaseResponse<>(response);
+    }
+
     /*
 
     @PostMapping("/code")
@@ -104,12 +113,6 @@ public class TeamController {
     public BaseResponse<String> unBookmarkTeam(HttpServletRequest httpRequest, @RequestBody @Valid TeamIdRequest request) {
         teamService.unBookmarkTeam(httpRequest, request);
         return new BaseResponse<>("모임을 즐겨찾기에서 삭제하였습니다.");
-    }
-
-    @GetMapping("/detail")
-    public BaseResponse<GetTeamResponse> getTeamDetail(HttpServletRequest httpRequest, @ModelAttribute @Valid TeamIdRequest request) {
-        GetTeamResponse response = teamService.getTeamDetail(httpRequest, request);
-        return new BaseResponse<>(response);
     }
 
     @GetMapping("/bookmark")

--- a/src/main/java/com/kuit/conet/dao/TeamDao.java
+++ b/src/main/java/com/kuit/conet/dao/TeamDao.java
@@ -180,11 +180,11 @@ public class TeamDao {
     }
 
     public Boolean isExistingUser(Long teamId, Long userId) {
-            String sql = "select exists(select * from team_member where user_id=:user_id and team_id=:team_id);";
-            Map<String, Object> param = Map.of("user_id", userId,
-                    "team_id", teamId);
+        String sql = "select exists(select * from team_member where user_id=:user_id and team_id=:team_id);";
+        Map<String, Object> param = Map.of("user_id", userId,
+                "team_id", teamId);
 
-            return jdbcTemplate.queryForObject(sql, param, Boolean.class);
+        return jdbcTemplate.queryForObject(sql, param, Boolean.class);
     }
 
     public Boolean isExistTeam(Long teamId) {
@@ -296,7 +296,7 @@ public class TeamDao {
             getTeamResponse.setTeamId(rs.getLong("team_id"));
             getTeamResponse.setTeamName(rs.getString("team_name"));
             getTeamResponse.setTeamImgUrl(rs.getString("team_image_url"));
-            getTeamResponse.setTeamMemberCount(rs.getLong("count(tm.user_id)"));
+            getTeamResponse.setTeamMemberCount(rs.getInt("count(tm.user_id)"));
             return getTeamResponse;
         };
 

--- a/src/main/java/com/kuit/conet/dto/web/response/team/GetTeamResponseDTO.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/team/GetTeamResponseDTO.java
@@ -1,5 +1,7 @@
 package com.kuit.conet.dto.web.response.team;
 
+import com.kuit.conet.jpa.domain.team.Team;
+import com.kuit.conet.jpa.service.validator.TeamValidator;
 import lombok.*;
 
 @Setter
@@ -11,14 +13,19 @@ public class GetTeamResponseDTO {
     private Long teamId;
     private String teamName;
     private String teamImgUrl;
-    private Long teamMemberCount;
+    private int teamMemberCount;
     private Boolean isNew;
     private Boolean bookmark;
 
-    public GetTeamResponseDTO(Long teamId, String teamName, String teamImgUrl, Long teamMemberCount) {
-        this.teamId = teamId;
-        this.teamName = teamName;
-        this.teamImgUrl = teamImgUrl;
+
+    public GetTeamResponseDTO(Team team, int teamMemberCount, Boolean bookmark) {
+        this.teamId = team.getId();
+        this.teamName = team.getName();
+        this.teamImgUrl = team.getImgUrl();
         this.teamMemberCount = teamMemberCount;
+        this.bookmark = bookmark;
+
+        //isNew 결정
+        this.isNew = TeamValidator.isNewTeam(team);
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -1,6 +1,5 @@
 package com.kuit.conet.jpa.repository;
 
-import com.kuit.conet.jpa.domain.team.Team;
 import com.kuit.conet.jpa.domain.team.TeamMember;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;
@@ -39,10 +38,10 @@ public class TeamMemberRepository {
                 .getSingleResult();
     }
 
-    public boolean isTeamMember(Team team, Long userId) {
-        return em.createQuery("select count(tm)>0 from TeamMember tm where tm.team=:team and tm.member.id=:userId", Boolean.class)
+    public boolean isTeamMember(Long teamId, Long userId) {
+        return em.createQuery("select count(tm)>0 from TeamMember tm where tm.team.id=:teamId and tm.member.id=:userId", Boolean.class)
                 .setParameter("userId", userId)
-                .setParameter("team", team)
+                .setParameter("teamId", teamId)
                 .getSingleResult();
     }
 

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -32,8 +32,8 @@ public class TeamMemberRepository {
     }
 
 
-    public Long getCount(Long id) {
-        return em.createQuery("select count(tm) from TeamMember tm where tm.team.id=:id", Long.class)
+    public Integer getCount(Long id) {
+        return em.createQuery("select count(tm) from TeamMember tm where tm.team.id=:id", Integer.class)
                 .setParameter("teamId", id)
                 .getSingleResult();
     }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamRepository.java
@@ -1,5 +1,6 @@
 package com.kuit.conet.jpa.repository;
 
+import com.kuit.conet.dto.web.response.team.GetTeamResponseDTO;
 import com.kuit.conet.jpa.domain.team.Team;
 import jakarta.persistence.EntityManager;
 import lombok.Getter;
@@ -58,5 +59,13 @@ public class TeamRepository {
         em.createQuery("delete from Team t where t.id=:teamId")
                 .setParameter("teamId", teamId)
                 .executeUpdate();
+    }
+
+    public GetTeamResponseDTO getTeamDetail(Long teamId, Long userId) {
+        return em.createQuery("select new com.kuit.conet.dto.web.response.team.GetTeamResponseDTO(t, size(t.teamMembers), tm.bookMark) " +
+                        "from Team t join t.teamMembers tm where t.id = :teamId and tm.member.id=:userId", GetTeamResponseDTO.class)
+                .setParameter("teamId", teamId)
+                .setParameter("userId", userId)
+                .getSingleResult();
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -141,8 +141,7 @@ public class TeamService {
         // 유저가 팀에 참가 중인지 검사
         isTeamMember(teamMemberRepository, teamId, userId);
 
-        GetTeamResponseDTO getTeamResponse = teamRepository.getTeamDetail(teamId);
-        getTeamResponse.setBookmark(teamRepository.getBookmark(userId, teamId));
+        GetTeamResponseDTO getTeamResponse = teamRepository.getTeamDetail(teamId, userId);
         return getTeamResponse;
     }
 

--- a/src/main/java/com/kuit/conet/jpa/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/TeamService.java
@@ -100,7 +100,7 @@ public class TeamService {
         validateTeamExisting(team);
 
         // 팀에 존재하는 멤버인지 확인
-        isTeamMember(teamMemberRepository, team, userId);
+        isTeamMember(teamMemberRepository, team.getId(), userId);
 
         //변경 감지 이용
         TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(team.getId(), userId);
@@ -116,7 +116,7 @@ public class TeamService {
         validateTeamExisting(team);
 
         // 모임 삭제 권한이 있는지 확인
-        isTeamMember(teamMemberRepository, team, userId);
+        isTeamMember(teamMemberRepository, teamId, userId);
 
         //image 삭제
         deleteImage(teamId);
@@ -132,10 +132,18 @@ public class TeamService {
 
     public List<GetTeamMemberResponseDTO> getTeamMembers(Long teamId, Long userId) {
         //팀 구성원인지 확인
-        Team team = teamRepository.findById(teamId);
-        isTeamMember(teamMemberRepository, team, userId);
+        isTeamMember(teamMemberRepository, teamId, userId);
 
         return memberRepository.getMembersByTeamId(teamId);
+    }
+
+    public GetTeamResponseDTO getTeamDetail(Long teamId, Long userId) {
+        // 유저가 팀에 참가 중인지 검사
+        isTeamMember(teamMemberRepository, teamId, userId);
+
+        GetTeamResponseDTO getTeamResponse = teamRepository.getTeamDetail(teamId);
+        getTeamResponse.setBookmark(teamRepository.getBookmark(userId, teamId));
+        return getTeamResponse;
     }
 
     private void deleteImage(Long teamId) {

--- a/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
+++ b/src/main/java/com/kuit/conet/jpa/service/validator/TeamValidator.java
@@ -60,8 +60,8 @@ public class TeamValidator {
         }
     }
 
-    public static void isTeamMember(TeamMemberRepository teamMemberRepository, Team team, Long userId) {
-        if (!teamMemberRepository.isTeamMember(team, userId)) {
+    public static void isTeamMember(TeamMemberRepository teamMemberRepository, Long teamId, Long userId) {
+        if (!teamMemberRepository.isTeamMember(teamId, userId)) {
             throw new TeamException(NOT_TEAM_MEMBER);
         }
     }

--- a/src/main/java/com/kuit/conet/service/TeamService.java
+++ b/src/main/java/com/kuit/conet/service/TeamService.java
@@ -140,20 +140,6 @@ public class TeamService {
         teamDao.unBookmarkTeam(userId, teamId);
     }
 
-    public GetTeamResponse getTeamDetail(HttpServletRequest httpRequest, TeamIdRequest request) {
-        Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
-        Long teamId = request.getTeamId();
-
-        // 유저가 팀에 참가 중인지 검사
-        if (!teamDao.isExistingUser(teamId, userId)) {
-            throw new TeamException(USER_NOT_EXIST_IN_TEAM);
-        }
-
-        GetTeamResponse getTeamResponse = teamDao.getTeamDetail(teamId);
-        getTeamResponse.setBookmark(teamDao.getBookmark(userId, teamId));
-        return getTeamResponse;
-    }
-
     public List<GetTeamResponse> getBookmarks(HttpServletRequest httpRequest) {
         Long userId = Long.parseLong((String) httpRequest.getAttribute("userId"));
 


### PR DESCRIPTION
## 변경 사항
- URI 변경
    - team/detail → team/{teamId}
- isTeamMember 인자값 Team→teamId로 수정
    - 위 메소드를 위해 teamId로 Team을 얻기 위한 불필요한 쿼리 제거
- GetTeamResponseDTO 생성자 인자 값 및 isNew까지 모두 해결하도록 수정
    - 서비스에서는 응답에 추가적인 set을 하지 않고 DTO 생성자에 역할을 위임

## API Test
<img width="832" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96986782/aad668a0-45f7-4413-ade6-8ab09f5c93f2">
