### PR TITLE
feat: 북마크 추가/삭제 api JPA 변환

### DIFF
--- a/src/main/java/com/kuit/conet/controller/MemberController.java
+++ b/src/main/java/com/kuit/conet/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.kuit.conet.controller;
 import com.kuit.conet.annotation.UserId;
 import com.kuit.conet.common.response.BaseResponse;
 import com.kuit.conet.dto.web.request.member.NameRequestDTO;
+import com.kuit.conet.dto.web.request.team.TeamIdRequestDTO;
 import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
 import com.kuit.conet.dto.web.response.member.MemberResponseDTO;
 import com.kuit.conet.dto.web.response.team.GetTeamResponseDTO;
@@ -52,15 +53,8 @@ public class MemberController {
         return new BaseResponse<>(responses);
     }
 
-/*    @PostMapping("/bookmark")
-    public BaseResponse<String> bookmarkTeam(HttpServletRequest httpRequest, @RequestBody @Valid TeamIdRequest request) {
-        teamService.bookmarkTeam(httpRequest, request);
-        return new BaseResponse<>("모임을 즐겨찾기에 추가하였습니다.");
+    @PostMapping("/bookmark")
+    public BaseResponse<String> bookmarkTeam(@UserId Long userId, @RequestBody @Valid TeamIdRequestDTO request) {
+        return new BaseResponse<>(memberService.bookmarkTeam(userId, request));
     }
-
-    @PostMapping("/bookmark/delete")
-    public BaseResponse<String> unBookmarkTeam(HttpServletRequest httpRequest, @RequestBody @Valid TeamIdRequest request) {
-        teamService.unBookmarkTeam(httpRequest, request);
-        return new BaseResponse<>("모임을 즐겨찾기에서 삭제하였습니다.");
-    }*/
 }

--- a/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/TeamMemberRepository.java
@@ -50,4 +50,12 @@ public class TeamMemberRepository {
                 .setParameter("teamId", teamId)
                 .executeUpdate();
     }
+
+    public void bookmarkTeam(Long userId, Long teamId) {
+        em.createQuery("update TeamMember tm set tm.bookMark = CASE WHEN tm.bookMark = true THEN false ELSE true END " +
+                        "where tm.member.id=:userId and tm.team.id=:teamId")
+                .setParameter("userId", userId)
+                .setParameter("teamId", teamId)
+                .executeUpdate();
+    }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/MemberService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.kuit.conet.jpa.service;
 
 import com.kuit.conet.dto.web.request.member.NameRequestDTO;
+import com.kuit.conet.dto.web.request.team.TeamIdRequestDTO;
 import com.kuit.conet.dto.web.response.StorageImgResponseDTO;
 import com.kuit.conet.dto.web.response.member.MemberResponseDTO;
 import com.kuit.conet.dto.web.response.team.GetTeamResponseDTO;
@@ -8,6 +9,7 @@ import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.storage.StorageDomain;
 import com.kuit.conet.jpa.repository.MemberRepository;
 import com.kuit.conet.jpa.repository.TeamMemberRepository;
+import com.kuit.conet.jpa.service.validator.TeamValidator;
 import com.kuit.conet.service.StorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,5 +79,20 @@ public class MemberService {
         List<GetTeamResponseDTO> teamResponses = memberRepository.getBookmarks(userId);
 
         return teamResponses;
+    }
+
+    public String bookmarkTeam(Long userId, TeamIdRequestDTO request) {
+        Long teamId = request.getTeamId();
+
+        // 유저가 팀에 참가 중인지 검사
+        TeamValidator.isTeamMember(teamMemberRepository, teamId, userId);
+
+        teamMemberRepository.bookmarkTeam(userId, teamId);
+
+        if (teamMemberRepository.isBookmark(userId, teamId)) {
+            return "모임을 즐겨찾기에 추가하였습니다.";
+        } else {
+            return "모임을 즐겨찾기에서 삭제하였습니다.";
+        }
     }
 }

--- a/src/main/java/com/kuit/conet/jpa/service/MemberService.java
+++ b/src/main/java/com/kuit/conet/jpa/service/MemberService.java
@@ -9,6 +9,7 @@ import com.kuit.conet.jpa.domain.member.Member;
 import com.kuit.conet.jpa.domain.storage.StorageDomain;
 import com.kuit.conet.jpa.repository.MemberRepository;
 import com.kuit.conet.jpa.repository.TeamMemberRepository;
+import com.kuit.conet.jpa.repository.TeamRepository;
 import com.kuit.conet.jpa.service.validator.TeamValidator;
 import com.kuit.conet.service.StorageService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.List;
 
 import static com.kuit.conet.jpa.service.validator.MemberValidator.validateActiveMember;
 import static com.kuit.conet.jpa.service.validator.MemberValidator.validateMemberExisting;
+import static com.kuit.conet.jpa.service.validator.TeamValidator.validateTeamExisting;
 import static com.kuit.conet.service.StorageService.getFileName;
 
 @Slf4j
@@ -31,6 +33,7 @@ import static com.kuit.conet.service.StorageService.getFileName;
 public class MemberService {
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
     private final StorageService storageService;
     @Value("${spring.user.default-image}")
     private String defaultImg;
@@ -76,13 +79,22 @@ public class MemberService {
     }
 
     public List<GetTeamResponseDTO> getBookmarks(Long userId) {
+        Member member = memberRepository.findById(userId);
+        validateMemberExisting(member);
+        validateActiveMember(member);
+
         List<GetTeamResponseDTO> teamResponses = memberRepository.getBookmarks(userId);
 
         return teamResponses;
     }
 
     public String bookmarkTeam(Long userId, TeamIdRequestDTO request) {
+        Member member = memberRepository.findById(userId);
+        validateMemberExisting(member);
+        validateActiveMember(member);
+
         Long teamId = request.getTeamId();
+        validateTeamExisting(teamRepository.findById(teamId));
 
         // 유저가 팀에 참가 중인지 검사
         TeamValidator.isTeamMember(teamMemberRepository, teamId, userId);


### PR DESCRIPTION
## 변경 사항
- 북마크 추가 api와 북마크 삭제 api 합침
  - 북마크 추가되어있는 상태에서 해당 api 호출하면 북마크 해제됨
  - 북마크 안되어있는 상태에서 해당 api 호출하면 북마크 추가됨

### URI 수정
- 북마크 삭제
`team/bookmark/delete` -> `user/bookmark`
- 북마크 추가
`team/bookmark` -> `user/bookmark`

### Request Body 필드명 수정

### Response 수정
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": "모임을 즐겨찾기에 추가하였습니다."
}
```
->
- 북마크 추가했을 때
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": "모임을 즐겨찾기에 추가하였습니다."
}
```
- 북마크 삭제했을 때
```json
{
    "code": 1000,
    "status": 200,
    "message": "요청에 성공하였습니다.",
    "result": "모임을 즐겨찾기에서 삭제하였습니다."
}
```

<br>

## API Test
<img width="1346" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/7ad1bb16-7873-419b-845a-03c8bb45fed8">
<img width="1346" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/793b42ca-f759-457a-a45f-ba55f427a290">
