### PR TITLE
fix: 홈화면 확정된 약속 조회 api 수정

### DIFF
--- a/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
+++ b/src/main/java/com/kuit/conet/jpa/repository/HomeRepository.java
@@ -18,12 +18,12 @@ public class HomeRepository {
     private final EntityManager em;
 
     public List<Date> getHomeFixedPlansInMonth(Long userId, String searchDate) {
-        // 해당 년, 월에 유저가 포함된 모든 모임의 모든 약속 -> fixed_date 만 distinct 로 검색
+        // 해당 년, 월에 유저가 포함된 약속(유저가 꼭 포함되어 있는 약속이어야 함) -> fixed_date 만 distinct 로 검색
         // team_member(userId, status) -> plan(teamId, fixed_date, status)
 
         return em.createQuery("select distinct p.fixedDate " +
-                        "from TeamMember tm join Plan p on tm.team.id = p.team.id " +
-                        "where tm.member.id = :userId " +
+                        "from PlanMembe정r pm join Plan p on pm.plan.id = p.id " +
+                        "where pm.member.id = :userId " +
                         "and p.status = :status " +
                         "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m') = :searchDate", Date.class)
                 .setParameter("userId", userId)
@@ -34,8 +34,8 @@ public class HomeRepository {
 
     public List<HomeFixedPlanOnDayDTO> getHomeFixedPlansOnDay(Long userId, String searchDate) {
         return em.createQuery("select new com.kuit.conet.dto.home.HomeFixedPlanOnDayDTO(p.id, p.fixedTime, p.team.name, p.name) " +
-                        "from TeamMember tm join Plan p on tm.team.id = p.team.id " +
-                        "where tm.member.id = :userId " +
+                        "from PlanMember pm join Plan p on pm.plan.id = p.id " +
+                        "where pm.member.id = :userId " +
                         "and p.status=:status " +
                         "and FUNCTION('DATE_FORMAT', p.fixedDate, '%Y-%m-%d')=:searchDate " +
                         "order by p.fixedTime", HomeFixedPlanOnDayDTO.class)


### PR DESCRIPTION
## 변경 사항
변경 이전: 홈화면에서 확정된 약속 조회할 때 해당 유저가 들어간 모든 모임의 모든 확정된 약속을 띄움
변경 이후: 홈화면에서 확정된 약속 조회할 때 해당 유저가 포함된 확정된 약속만 띄움

### URI 수정
- 홈 화면 특정 달의 확정된 약속 조회
/home/month?searchDate={searchMonth}
-> /home/plan/month?searchDate={searchMonth}

- 홈 화면 특정 날짜의 확정된 약속 조회
/home/day?searchDate={searchDate}
-> /home/plan/day?searchDate={searchDate}

### Request Body 필드명 수정

### Response 수정

<br>

## API Test
<img width="1047" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/07df53cf-5f0a-4570-8180-4cc13fedf18f">

<img width="1057" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/81250561/3bbeedb5-d6ab-4c49-8544-d3233d8392e6">
