### PR TITLE
refactor: 특정 약속의 나의 가능한 시간 조회 response 리팩토링

### DIFF
--- a/src/main/java/com/kuit/conet/dto/web/response/plan/UserAvailableTimeResponseDTO.java
+++ b/src/main/java/com/kuit/conet/dto/web/response/plan/UserAvailableTimeResponseDTO.java
@@ -5,21 +5,21 @@ import lombok.*;
 
 import java.util.List;
 
+import static com.kuit.conet.jpa.domain.plan.AvailableTimeRegisteredStatus.*;
+
 @Getter
 @NoArgsConstructor
 public class UserAvailableTimeResponseDTO {
     private Long planId;
     private Long userId;
-    private Boolean hasRegisteredTime; // 가능한 시간을 입력했는지
-    private Boolean hasAvailableTime; // 가능한 시간이 존재하는지
+    private int availableTimeRegisteredStatus;
     private List<UserAvailableTimeDTO> timeSlot;
 
     public static UserAvailableTimeResponseDTO notRegistered(Long planId, Long userId) {
         UserAvailableTimeResponseDTO responseDTO = new UserAvailableTimeResponseDTO();
         responseDTO.planId = planId;
         responseDTO.userId = userId;
-        responseDTO.hasRegisteredTime = false;
-        responseDTO.hasAvailableTime = false;
+        responseDTO.availableTimeRegisteredStatus = NOT_REGISTERED.getStatus();
         responseDTO.timeSlot = null;
 
         return responseDTO;
@@ -29,8 +29,12 @@ public class UserAvailableTimeResponseDTO {
         UserAvailableTimeResponseDTO responseDTO = new UserAvailableTimeResponseDTO();
         responseDTO.planId = planId;
         responseDTO.userId = userId;
-        responseDTO.hasRegisteredTime = true;
-        responseDTO.hasAvailableTime = hasAvailableTime;
+        if (!hasAvailableTime) {
+            responseDTO.availableTimeRegisteredStatus = NO_AVAILABLE_TIME.getStatus();
+        }
+        if (hasAvailableTime) {
+            responseDTO.availableTimeRegisteredStatus = HAS_AVAILABLE_TIME.getStatus();
+        }
         responseDTO.timeSlot = timeSlot;
 
         return responseDTO;

--- a/src/main/java/com/kuit/conet/jpa/domain/auth/Platform.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/auth/Platform.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import static com.kuit.conet.common.response.status.BaseExceptionResponseStatus.INVALID_PLATFORM;
 
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public enum Platform {
     APPLE("APPLE"),

--- a/src/main/java/com/kuit/conet/jpa/domain/plan/AvailableTimeRegisteredStatus.java
+++ b/src/main/java/com/kuit/conet/jpa/domain/plan/AvailableTimeRegisteredStatus.java
@@ -1,0 +1,15 @@
+package com.kuit.conet.jpa.domain.plan;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AvailableTimeRegisteredStatus {
+    NOT_REGISTERED(0),
+    NO_AVAILABLE_TIME(1),
+    HAS_AVAILABLE_TIME(2);
+
+    private int status;
+
+}


### PR DESCRIPTION
### 가능한 시간 입력, 존재 여부를 하나의 값으로 전달하도록 리팩토링

## 변경 사항
### Response 수정
`hasRegisteredTime`, `hasAvailableTime` 삭제
-> int 타입의 `availableTimeRegisteredStatus` 추가
<img width="391" alt="image" src="https://github.com/KUIT-CoNet/CoNet-Server-JPA/assets/96233738/e4f34b39-8415-4823-8020-e8405b2dcf92">
